### PR TITLE
Syntax error in deployment script

### DIFF
--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install depot_tools
         run: |
           git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git ../depot_tools
-          export "PATH=$PWD/../depot_tools:$PATH
+          export PATH=$PWD/../depot_tools:$PATH
           gclient
       - name: Sync deps
         run: |


### PR DESCRIPTION
This CL fixes an extra '"' in the deploy script.

Issue #10