### PR TITLE
Combine depot_tools and sync in deploy script.

### DIFF
--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -28,13 +28,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup Pages
         uses: actions/configure-pages@v2
-      - name: Install depot_tools
+      - name: Install depot_tools and sync deps
         run: |
           git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git ../depot_tools
           export PATH=$PWD/../depot_tools:$PATH
-          gclient
-      - name: Sync deps
-        run: |
           gclient sync --jobs=16
       - name: Build API docs
         run: |


### PR DESCRIPTION
Combine the sync and depot_tools call into a single entry in the deploy script to fixup path issues.

Issue #10