### PR TITLE
Add header for std::array in example_05

### DIFF
--- a/src/example_05/main.cc
+++ b/src/example_05/main.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <array>
 #include <cassert>
 #include <chrono>
 #include <cmath>


### PR DESCRIPTION
Compilation fails otherwise depending on the compiler/standard library.