### PR TITLE
Update dawn, adapt samples to updated APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ out
 .cipd
 .gclient_entries
 .gclient_previous_sync_commits
+.gcs_entries
 third_party/dawn

--- a/DEPS
+++ b/DEPS
@@ -6,7 +6,7 @@ vars = {
 
 deps = {
   'third_party/dawn':
-      '{dawn_git}/dawn@1058e7aa5067e0415b77fc3ae8a340157a11d9e8',
+      '{dawn_git}/dawn@cda4e1d07860e12aa1721d8ca6899f1709df0aa3',
 }
 
 recursedeps = [

--- a/src/example_01/dump_utils.cc
+++ b/src/example_01/dump_utils.cc
@@ -17,9 +17,16 @@
 #include <cassert>
 #include <iostream>
 #include <sstream>
+#include <string_view>
 #include <vector>
 
 namespace dusk::dump_utils {
+
+namespace {
+std::string str(const wgpu::StringView& s) {
+  return {s.data, s.length};
+}
+}  // namespace
 
 std::string FeatureNameToString(wgpu::FeatureName f) {
   switch (f) {
@@ -29,8 +36,6 @@ std::string FeatureNameToString(wgpu::FeatureName f) {
       return "Depth32FloatStencil8";
     case wgpu::FeatureName::TimestampQuery:
       return "TimestampQuery";
-    case wgpu::FeatureName::PipelineStatisticsQuery:
-      return "PipelineStatisticsQuery";
     case wgpu::FeatureName::TextureCompressionBC:
       return "TextureCompressionBC";
     case wgpu::FeatureName::TextureCompressionETC2:
@@ -39,26 +44,134 @@ std::string FeatureNameToString(wgpu::FeatureName f) {
       return "TextureCompressionASTC";
     case wgpu::FeatureName::IndirectFirstInstance:
       return "IndirectFirstInstance";
-    case wgpu::FeatureName::DawnShaderFloat16:
-      return "DawnShaderFloat16";
+    case wgpu::FeatureName::ShaderF16:
+      return "ShaderF16";
+    case wgpu::FeatureName::RG11B10UfloatRenderable:
+      return "RG11B10UfloatRenderable";
+    case wgpu::FeatureName::BGRA8UnormStorage:
+      return "BGRA8UnormStorage";
+    case wgpu::FeatureName::Float32Filterable:
+      return "Float32Filterable";
+    case wgpu::FeatureName::Float32Blendable:
+      return "Float32Blendable";
+    case wgpu::FeatureName::Subgroups:
+      return "Subgroups";
+    case wgpu::FeatureName::SubgroupsF16:
+      return "SubgroupsF16";
     case wgpu::FeatureName::DawnInternalUsages:
       return "DawnInternalUsages";
     case wgpu::FeatureName::DawnMultiPlanarFormats:
       return "DawnMultiPlanarFormats";
     case wgpu::FeatureName::DawnNative:
       return "DawnNative";
-    case wgpu::FeatureName::ChromiumExperimentalDp4a:
-      return "ChromiumExperimentalDp4a";
-    case wgpu::FeatureName::TimestampQueryInsidePasses:
-      return "TimestampQueryInsidePasses";
-    case wgpu::FeatureName::ShaderF16:
-      return "ShaderF16";
-    case wgpu::FeatureName::RG11B10UfloatRenderable:
-      return "RG11B10UfloatRenderable";
-    case wgpu::FeatureName::Undefined:
-      break;
+    case wgpu::FeatureName::ChromiumExperimentalTimestampQueryInsidePasses:
+      return "ChromiumExperimentalTimestampQueryInsidePasses";
+    case wgpu::FeatureName::ImplicitDeviceSynchronization:
+      return "ImplicitDeviceSynchronization";
+    case wgpu::FeatureName::ChromiumExperimentalImmediateData:
+      return "ChromiumExperimentalImmediateData";
+    case wgpu::FeatureName::TransientAttachments:
+      return "TransientAttachments";
+    case wgpu::FeatureName::MSAARenderToSingleSampled:
+      return "MSAARenderToSingleSampled";
+    case wgpu::FeatureName::DualSourceBlending:
+      return "DualSourceBlending";
+    case wgpu::FeatureName::D3D11MultithreadProtected:
+      return "D3D11MultithreadProtected";
+    case wgpu::FeatureName::ANGLETextureSharing:
+      return "ANGLETextureSharing";
+    case wgpu::FeatureName::PixelLocalStorageCoherent:
+      return "PixelLocalStorageCoherent";
+    case wgpu::FeatureName::PixelLocalStorageNonCoherent:
+      return "PixelLocalStorageNonCoherent";
+    case wgpu::FeatureName::Unorm16TextureFormats:
+      return "Unorm16TextureFormats";
+    case wgpu::FeatureName::Snorm16TextureFormats:
+      return "Snorm16TextureFormats";
+    case wgpu::FeatureName::MultiPlanarFormatExtendedUsages:
+      return "MultiPlanarFormatExtendedUsages";
+    case wgpu::FeatureName::MultiPlanarFormatP010:
+      return "MultiPlanarFormatP010";
+    case wgpu::FeatureName::HostMappedPointer:
+      return "HostMappedPointer";
+    case wgpu::FeatureName::MultiPlanarRenderTargets:
+      return "MultiPlanarRenderTargets";
+    case wgpu::FeatureName::MultiPlanarFormatNv12a:
+      return "MultiPlanarFormatNv12a";
+    case wgpu::FeatureName::FramebufferFetch:
+      return "FramebufferFetch";
+    case wgpu::FeatureName::BufferMapExtendedUsages:
+      return "BufferMapExtendedUsages";
+    case wgpu::FeatureName::AdapterPropertiesMemoryHeaps:
+      return "AdapterPropertiesMemoryHeaps";
+    case wgpu::FeatureName::AdapterPropertiesD3D:
+      return "AdapterPropertiesD3D";
+    case wgpu::FeatureName::AdapterPropertiesVk:
+      return "AdapterPropertiesVk";
+    case wgpu::FeatureName::R8UnormStorage:
+      return "R8UnormStorage";
+    case wgpu::FeatureName::FormatCapabilities:
+      return "FormatCapabilities";
+    case wgpu::FeatureName::DrmFormatCapabilities:
+      return "DrmFormatCapabilities";
+    case wgpu::FeatureName::Norm16TextureFormats:
+      return "Norm16TextureFormats";
+    case wgpu::FeatureName::MultiPlanarFormatNv16:
+      return "MultiPlanarFormatNv16";
+    case wgpu::FeatureName::MultiPlanarFormatNv24:
+      return "MultiPlanarFormatNv24";
+    case wgpu::FeatureName::MultiPlanarFormatP210:
+      return "MultiPlanarFormatP210";
+    case wgpu::FeatureName::MultiPlanarFormatP410:
+      return "MultiPlanarFormatP410";
+    case wgpu::FeatureName::SharedTextureMemoryVkDedicatedAllocation:
+      return "SharedTextureMemoryVkDedicatedAllocation";
+    case wgpu::FeatureName::SharedTextureMemoryAHardwareBuffer:
+      return "SharedTextureMemoryAHardwareBuffer";
+    case wgpu::FeatureName::SharedTextureMemoryDmaBuf:
+      return "SharedTextureMemoryDmaBuf";
+    case wgpu::FeatureName::SharedTextureMemoryOpaqueFD:
+      return "SharedTextureMemoryOpaqueFD";
+    case wgpu::FeatureName::SharedTextureMemoryZirconHandle:
+      return "SharedTextureMemoryZirconHandle";
+    case wgpu::FeatureName::SharedTextureMemoryDXGISharedHandle:
+      return "SharedTextureMemoryDXGISharedHandle";
+    case wgpu::FeatureName::SharedTextureMemoryD3D11Texture2D:
+      return "SharedTextureMemoryD3D11Texture2D";
+    case wgpu::FeatureName::SharedTextureMemoryIOSurface:
+      return "SharedTextureMemoryIOSurface";
+    case wgpu::FeatureName::SharedTextureMemoryEGLImage:
+      return "SharedTextureMemoryEGLImage";
+    case wgpu::FeatureName::SharedFenceVkSemaphoreOpaqueFD:
+      return "SharedFenceVkSemaphoreOpaqueFD";
+    case wgpu::FeatureName::SharedFenceSyncFD:
+      return "SharedFenceSyncFD";
+    case wgpu::FeatureName::SharedFenceVkSemaphoreZirconHandle:
+      return "SharedFenceVkSemaphoreZirconHandle";
+    case wgpu::FeatureName::SharedFenceDXGISharedHandle:
+      return "SharedFenceDXGISharedHandle";
+    case wgpu::FeatureName::SharedFenceMTLSharedEvent:
+      return "SharedFenceMTLSharedEvent";
+    case wgpu::FeatureName::SharedBufferMemoryD3D12Resource:
+      return "SharedBufferMemoryD3D12Resource";
+    case wgpu::FeatureName::StaticSamplers:
+      return "StaticSamplers";
+    case wgpu::FeatureName::YCbCrVulkanSamplers:
+      return "YCbCrVulkanSamplers";
+    case wgpu::FeatureName::ShaderModuleCompilationOptions:
+      return "ShaderModuleCompilationOptions";
+    case wgpu::FeatureName::DawnLoadResolveTexture:
+      return "DawnLoadResolveTexture";
+    case wgpu::FeatureName::DawnPartialLoadResolveTexture:
+      return "DawnPartialLoadResolveTexture";
+    case wgpu::FeatureName::MultiDrawIndirect:
+      return "MultiDrawIndirect";
+    case wgpu::FeatureName::ClipDistances:
+      return "ClipDistances";
+    case wgpu::FeatureName::DawnTexelCopyBufferRowAlignment:
+      return "DawnTexelCopyBufferRowAlignment";
   }
-  return "Undefined";
+  return "Unknown";
 }
 
 std::string AdapterTypeToString(wgpu::AdapterType type) {
@@ -93,23 +206,23 @@ std::string BackendTypeToString(wgpu::BackendType type) {
       return "OpenGL";
     case wgpu::BackendType::OpenGLES:
       return "OpenGLES";
+    case wgpu::BackendType::Undefined:
+      return "Undefined";
   }
   return "unknown";
 }
 
-std::string AdapterPropertiesToString(const wgpu::AdapterProperties& props) {
-  assert(props.nextInChain == nullptr);
+std::string AdapterInfoToString(const wgpu::AdapterInfo& info) {
+  assert(info.nextInChain == nullptr);
 
   std::stringstream out;
-  out << "VendorID: " << props.vendorID << std::endl;
-  out << "Vendor: " << props.vendorName << std::endl;
-  out << "Architecture: " << props.architecture << std::endl;
-  out << "DeviceID: " << props.deviceID << std::endl;
-  out << "Name: " << props.name << std::endl;
-  out << "Driver description: " << props.driverDescription << std::endl;
-  out << "Adapter Type: " << AdapterTypeToString(props.adapterType)
+  out << "Vendor: " << str(info.vendor) << std::endl;
+  out << "Architecture: " << str(info.architecture) << std::endl;
+  out << "Device: " << str(info.device) << std::endl;
+  out << "Description: " << str(info.description) << std::endl;
+  out << "Adapter Type: " << AdapterTypeToString(info.adapterType)
       << std::endl;
-  out << "Backend Type: " << BackendTypeToString(props.backendType)
+  out << "Backend Type: " << BackendTypeToString(info.backendType)
       << std::endl;
   return out.str();
 }
@@ -201,19 +314,18 @@ std::string LimitsToString(const wgpu::Limits& limits,
   return out.str();
 }
 
-void DumpAdapterProperties(wgpu::Adapter& adapter) {
-  wgpu::AdapterProperties properties;
-  adapter.GetProperties(&properties);
-  std::cerr << AdapterPropertiesToString(properties) << std::endl;
+void DumpAdapterInfo(wgpu::Adapter& adapter) {
+  wgpu::AdapterInfo info;
+  adapter.GetInfo(&info);
+  std::cerr << AdapterInfoToString(info) << std::endl;
 }
 
 void DumpAdapterFeatures(wgpu::Adapter& adapter) {
-  auto feature_count = adapter.EnumerateFeatures(nullptr);
-  std::vector<wgpu::FeatureName> features(feature_count);
-  adapter.EnumerateFeatures(features.data());
+  wgpu::SupportedFeatures f;
+  adapter.GetFeatures(&f);
   std::cerr << "Adapter Extensions:" << std::endl;
-  for (const auto& f : features) {
-    std::cerr << "  " << FeatureNameToString(f) << std::endl;
+  for (size_t i = 0; i < f.featureCount; ++i) {
+    std::cerr << "  " << FeatureNameToString(f.features[i]) << std::endl;
   }
 }
 
@@ -226,18 +338,17 @@ void DumpAdapterLimits(wgpu::Adapter& adapter) {
 }
 
 void DumpAdapter(wgpu::Adapter& adapter) {
-  DumpAdapterProperties(adapter);
+  DumpAdapterInfo(adapter);
   DumpAdapterFeatures(adapter);
   DumpAdapterLimits(adapter);
 }
 
 void DumpDeviceFeatures(wgpu::Device& device) {
-  auto feature_count = device.EnumerateFeatures(nullptr);
-  std::vector<wgpu::FeatureName> features(feature_count);
-  device.EnumerateFeatures(features.data());
+  wgpu::SupportedFeatures f;
+  device.GetFeatures(&f);
   std::cerr << "Device Extensions:" << std::endl;
-  for (const auto& f : features) {
-    std::cerr << "  " << FeatureNameToString(f) << std::endl;
+  for (size_t i = 0; i < f.featureCount; ++i) {
+    std::cerr << "  " << FeatureNameToString(f.features[i]) << std::endl;
   }
 }
 

--- a/src/example_01/dump_utils.h
+++ b/src/example_01/dump_utils.h
@@ -23,13 +23,13 @@ namespace dusk::dump_utils {
 std::string FeatureNameToString(wgpu::FeatureName f);
 std::string AdapterTypeToString(wgpu::AdapterType type);
 std::string BackendTypeToString(wgpu::BackendType type);
-std::string AdapterPropertiesToString(const wgpu::AdapterProperties& props);
+std::string AdapterInfoToString(const wgpu::AdapterInfo& info);
 std::string FormatNumber(uint64_t num);
 
 std::string LimitsToString(const wgpu::Limits& limits,
                            const std::string& indent);
 
-void DumpAdapterProperties(wgpu::Adapter& adapter);
+void DumpAdapterInfo(wgpu::Adapter& adapter);
 void DumpAdapterFeatures(wgpu::Adapter& adapter);
 void DumpAdapterLimits(wgpu::Adapter& adapter);
 void DumpAdapter(wgpu::Adapter& adapter);

--- a/src/example_01/main.cc
+++ b/src/example_01/main.cc
@@ -22,7 +22,7 @@ int main() {
   wgpu::Adapter adapter;
   instance.RequestAdapter(
       nullptr,
-      [](WGPURequestAdapterStatus, WGPUAdapter adapterIn, const char*,
+      [](WGPURequestAdapterStatus, WGPUAdapter adapterIn, WGPUStringView,
          void* userdata) {
         *static_cast<wgpu::Adapter*>(userdata) =
             wgpu::Adapter::Acquire(adapterIn);

--- a/src/example_02/callbacks.cc
+++ b/src/example_02/callbacks.cc
@@ -18,40 +18,50 @@
 
 namespace dusk::cb {
 
-void Error(WGPUErrorType type, const char* msg, void*) {
+namespace {
+std::string_view str(const WGPUStringView& s) {
+  return {s.data, s.length};
+}
+}  // anonymous namespace
+
+void Error(const wgpu::Device&, wgpu::ErrorType type, const char* msg) {
   switch (type) {
-    case WGPUErrorType_OutOfMemory:
+    case wgpu::ErrorType::OutOfMemory:
       std::cerr << "[Error] Out Of Memory: " << msg << std::endl;
       abort();
-    case WGPUErrorType_Validation:
+    case wgpu::ErrorType::Validation:
       std::cerr << "[Error Validation: " << msg << std::endl;
       abort();
-    case WGPUErrorType_NoError:
-    case WGPUErrorType_Unknown:
-    case WGPUErrorType_DeviceLost:
-    case WGPUErrorType_Force32:
-    case WGPUErrorType_Internal:
+    case wgpu::ErrorType::NoError:
+    case wgpu::ErrorType::Unknown:
+    case wgpu::ErrorType::DeviceLost:
+    case wgpu::ErrorType::Internal:
       std::cerr << msg << std::endl;
       break;
   }
 }
 
-void DeviceLost(WGPUDeviceLostReason reason, char const* msg, void*) {
+void DeviceLost(const wgpu::Device&,
+                wgpu::DeviceLostReason reason,
+                const char* msg) {
   std::cerr << "[Device Lost]: ";
   switch (reason) {
-    case WGPUDeviceLostReason_Undefined:
+    case wgpu::DeviceLostReason::Unknown:
       std::cerr << "Undefined: " << msg << std::endl;
       break;
-    case WGPUDeviceLostReason_Destroyed:
+    case wgpu::DeviceLostReason::Destroyed:
       std::cerr << "Destroyed: " << msg << std::endl;
       break;
-    case WGPUDeviceLostReason_Force32:
-      std::cerr << "Force32: " << msg << std::endl;
+    case wgpu::DeviceLostReason::InstanceDropped:
+      std::cerr << "InstanceDropped: " << msg << std::endl;
+      break;
+    case wgpu::DeviceLostReason::FailedCreation:
+      std::cerr << "FailedCreation: " << msg << std::endl;
       break;
   }
 }
 
-void Logging(WGPULoggingType type, const char* msg, void*) {
+void Logging(WGPULoggingType type, WGPUStringView msg, void*) {
   switch (type) {
     case WGPULoggingType_Verbose:
       std::cerr << "Log [Verbose]: ";
@@ -69,7 +79,7 @@ void Logging(WGPULoggingType type, const char* msg, void*) {
       std::cerr << "Log [Force32]: ";
       break;
   }
-  std::cerr << msg << std::endl;
+  std::cerr << str(msg) << std::endl;
 }
 
 }  // namespace dusk::cb

--- a/src/example_02/callbacks.h
+++ b/src/example_02/callbacks.h
@@ -18,8 +18,10 @@
 
 namespace dusk::cb {
 
-void Error(WGPUErrorType type, const char* msg, void*);
-void DeviceLost(WGPUDeviceLostReason reason, char const* msg, void*);
-void Logging(WGPULoggingType type, const char* msg, void*);
+void Error(const wgpu::Device&, wgpu::ErrorType type, const char* msg);
+void DeviceLost(const wgpu::Device&,
+                wgpu::DeviceLostReason reason,
+                const char* msg);
+void Logging(WGPULoggingType type, WGPUStringView msg, void*);
 
 }  // namespace dusk::cb

--- a/src/example_02/dump_utils.cc
+++ b/src/example_02/dump_utils.cc
@@ -17,9 +17,16 @@
 #include <cassert>
 #include <iostream>
 #include <sstream>
+#include <string_view>
 #include <vector>
 
 namespace dusk::dump_utils {
+
+namespace {
+std::string str(const wgpu::StringView& s) {
+  return {s.data, s.length};
+}
+}  // namespace
 
 std::string FeatureNameToString(wgpu::FeatureName f) {
   switch (f) {
@@ -29,8 +36,6 @@ std::string FeatureNameToString(wgpu::FeatureName f) {
       return "Depth32FloatStencil8";
     case wgpu::FeatureName::TimestampQuery:
       return "TimestampQuery";
-    case wgpu::FeatureName::PipelineStatisticsQuery:
-      return "PipelineStatisticsQuery";
     case wgpu::FeatureName::TextureCompressionBC:
       return "TextureCompressionBC";
     case wgpu::FeatureName::TextureCompressionETC2:
@@ -39,26 +44,134 @@ std::string FeatureNameToString(wgpu::FeatureName f) {
       return "TextureCompressionASTC";
     case wgpu::FeatureName::IndirectFirstInstance:
       return "IndirectFirstInstance";
-    case wgpu::FeatureName::DawnShaderFloat16:
-      return "DawnShaderFloat16";
+    case wgpu::FeatureName::ShaderF16:
+      return "ShaderF16";
+    case wgpu::FeatureName::RG11B10UfloatRenderable:
+      return "RG11B10UfloatRenderable";
+    case wgpu::FeatureName::BGRA8UnormStorage:
+      return "BGRA8UnormStorage";
+    case wgpu::FeatureName::Float32Filterable:
+      return "Float32Filterable";
+    case wgpu::FeatureName::Float32Blendable:
+      return "Float32Blendable";
+    case wgpu::FeatureName::Subgroups:
+      return "Subgroups";
+    case wgpu::FeatureName::SubgroupsF16:
+      return "SubgroupsF16";
     case wgpu::FeatureName::DawnInternalUsages:
       return "DawnInternalUsages";
     case wgpu::FeatureName::DawnMultiPlanarFormats:
       return "DawnMultiPlanarFormats";
     case wgpu::FeatureName::DawnNative:
       return "DawnNative";
-    case wgpu::FeatureName::ChromiumExperimentalDp4a:
-      return "ChromiumExperimentalDp4a";
-    case wgpu::FeatureName::TimestampQueryInsidePasses:
-      return "TimestampQueryInsidePasses";
-    case wgpu::FeatureName::ShaderF16:
-      return "ShaderF16";
-    case wgpu::FeatureName::RG11B10UfloatRenderable:
-      return "RG11B10UfloatRenderable";
-    case wgpu::FeatureName::Undefined:
-      break;
+    case wgpu::FeatureName::ChromiumExperimentalTimestampQueryInsidePasses:
+      return "ChromiumExperimentalTimestampQueryInsidePasses";
+    case wgpu::FeatureName::ImplicitDeviceSynchronization:
+      return "ImplicitDeviceSynchronization";
+    case wgpu::FeatureName::ChromiumExperimentalImmediateData:
+      return "ChromiumExperimentalImmediateData";
+    case wgpu::FeatureName::TransientAttachments:
+      return "TransientAttachments";
+    case wgpu::FeatureName::MSAARenderToSingleSampled:
+      return "MSAARenderToSingleSampled";
+    case wgpu::FeatureName::DualSourceBlending:
+      return "DualSourceBlending";
+    case wgpu::FeatureName::D3D11MultithreadProtected:
+      return "D3D11MultithreadProtected";
+    case wgpu::FeatureName::ANGLETextureSharing:
+      return "ANGLETextureSharing";
+    case wgpu::FeatureName::PixelLocalStorageCoherent:
+      return "PixelLocalStorageCoherent";
+    case wgpu::FeatureName::PixelLocalStorageNonCoherent:
+      return "PixelLocalStorageNonCoherent";
+    case wgpu::FeatureName::Unorm16TextureFormats:
+      return "Unorm16TextureFormats";
+    case wgpu::FeatureName::Snorm16TextureFormats:
+      return "Snorm16TextureFormats";
+    case wgpu::FeatureName::MultiPlanarFormatExtendedUsages:
+      return "MultiPlanarFormatExtendedUsages";
+    case wgpu::FeatureName::MultiPlanarFormatP010:
+      return "MultiPlanarFormatP010";
+    case wgpu::FeatureName::HostMappedPointer:
+      return "HostMappedPointer";
+    case wgpu::FeatureName::MultiPlanarRenderTargets:
+      return "MultiPlanarRenderTargets";
+    case wgpu::FeatureName::MultiPlanarFormatNv12a:
+      return "MultiPlanarFormatNv12a";
+    case wgpu::FeatureName::FramebufferFetch:
+      return "FramebufferFetch";
+    case wgpu::FeatureName::BufferMapExtendedUsages:
+      return "BufferMapExtendedUsages";
+    case wgpu::FeatureName::AdapterPropertiesMemoryHeaps:
+      return "AdapterPropertiesMemoryHeaps";
+    case wgpu::FeatureName::AdapterPropertiesD3D:
+      return "AdapterPropertiesD3D";
+    case wgpu::FeatureName::AdapterPropertiesVk:
+      return "AdapterPropertiesVk";
+    case wgpu::FeatureName::R8UnormStorage:
+      return "R8UnormStorage";
+    case wgpu::FeatureName::FormatCapabilities:
+      return "FormatCapabilities";
+    case wgpu::FeatureName::DrmFormatCapabilities:
+      return "DrmFormatCapabilities";
+    case wgpu::FeatureName::Norm16TextureFormats:
+      return "Norm16TextureFormats";
+    case wgpu::FeatureName::MultiPlanarFormatNv16:
+      return "MultiPlanarFormatNv16";
+    case wgpu::FeatureName::MultiPlanarFormatNv24:
+      return "MultiPlanarFormatNv24";
+    case wgpu::FeatureName::MultiPlanarFormatP210:
+      return "MultiPlanarFormatP210";
+    case wgpu::FeatureName::MultiPlanarFormatP410:
+      return "MultiPlanarFormatP410";
+    case wgpu::FeatureName::SharedTextureMemoryVkDedicatedAllocation:
+      return "SharedTextureMemoryVkDedicatedAllocation";
+    case wgpu::FeatureName::SharedTextureMemoryAHardwareBuffer:
+      return "SharedTextureMemoryAHardwareBuffer";
+    case wgpu::FeatureName::SharedTextureMemoryDmaBuf:
+      return "SharedTextureMemoryDmaBuf";
+    case wgpu::FeatureName::SharedTextureMemoryOpaqueFD:
+      return "SharedTextureMemoryOpaqueFD";
+    case wgpu::FeatureName::SharedTextureMemoryZirconHandle:
+      return "SharedTextureMemoryZirconHandle";
+    case wgpu::FeatureName::SharedTextureMemoryDXGISharedHandle:
+      return "SharedTextureMemoryDXGISharedHandle";
+    case wgpu::FeatureName::SharedTextureMemoryD3D11Texture2D:
+      return "SharedTextureMemoryD3D11Texture2D";
+    case wgpu::FeatureName::SharedTextureMemoryIOSurface:
+      return "SharedTextureMemoryIOSurface";
+    case wgpu::FeatureName::SharedTextureMemoryEGLImage:
+      return "SharedTextureMemoryEGLImage";
+    case wgpu::FeatureName::SharedFenceVkSemaphoreOpaqueFD:
+      return "SharedFenceVkSemaphoreOpaqueFD";
+    case wgpu::FeatureName::SharedFenceSyncFD:
+      return "SharedFenceSyncFD";
+    case wgpu::FeatureName::SharedFenceVkSemaphoreZirconHandle:
+      return "SharedFenceVkSemaphoreZirconHandle";
+    case wgpu::FeatureName::SharedFenceDXGISharedHandle:
+      return "SharedFenceDXGISharedHandle";
+    case wgpu::FeatureName::SharedFenceMTLSharedEvent:
+      return "SharedFenceMTLSharedEvent";
+    case wgpu::FeatureName::SharedBufferMemoryD3D12Resource:
+      return "SharedBufferMemoryD3D12Resource";
+    case wgpu::FeatureName::StaticSamplers:
+      return "StaticSamplers";
+    case wgpu::FeatureName::YCbCrVulkanSamplers:
+      return "YCbCrVulkanSamplers";
+    case wgpu::FeatureName::ShaderModuleCompilationOptions:
+      return "ShaderModuleCompilationOptions";
+    case wgpu::FeatureName::DawnLoadResolveTexture:
+      return "DawnLoadResolveTexture";
+    case wgpu::FeatureName::DawnPartialLoadResolveTexture:
+      return "DawnPartialLoadResolveTexture";
+    case wgpu::FeatureName::MultiDrawIndirect:
+      return "MultiDrawIndirect";
+    case wgpu::FeatureName::ClipDistances:
+      return "ClipDistances";
+    case wgpu::FeatureName::DawnTexelCopyBufferRowAlignment:
+      return "DawnTexelCopyBufferRowAlignment";
   }
-  return "Undefined";
+  return "Unknown";
 }
 
 std::string AdapterTypeToString(wgpu::AdapterType type) {
@@ -93,23 +206,23 @@ std::string BackendTypeToString(wgpu::BackendType type) {
       return "OpenGL";
     case wgpu::BackendType::OpenGLES:
       return "OpenGLES";
+    case wgpu::BackendType::Undefined:
+      return "Undefined";
   }
   return "unknown";
 }
 
-std::string AdapterPropertiesToString(const wgpu::AdapterProperties& props) {
-  assert(props.nextInChain == nullptr);
+std::string AdapterInfoToString(const wgpu::AdapterInfo& info) {
+  assert(info.nextInChain == nullptr);
 
   std::stringstream out;
-  out << "VendorID: " << props.vendorID << std::endl;
-  out << "Vendor: " << props.vendorName << std::endl;
-  out << "Architecture: " << props.architecture << std::endl;
-  out << "DeviceID: " << props.deviceID << std::endl;
-  out << "Name: " << props.name << std::endl;
-  out << "Driver description: " << props.driverDescription << std::endl;
-  out << "Adapter Type: " << AdapterTypeToString(props.adapterType)
+  out << "Vendor: " << str(info.vendor) << std::endl;
+  out << "Architecture: " << str(info.architecture) << std::endl;
+  out << "Device: " << str(info.device) << std::endl;
+  out << "Description: " << str(info.description) << std::endl;
+  out << "Adapter Type: " << AdapterTypeToString(info.adapterType)
       << std::endl;
-  out << "Backend Type: " << BackendTypeToString(props.backendType)
+  out << "Backend Type: " << BackendTypeToString(info.backendType)
       << std::endl;
   return out.str();
 }
@@ -201,19 +314,18 @@ std::string LimitsToString(const wgpu::Limits& limits,
   return out.str();
 }
 
-void DumpAdapterProperties(wgpu::Adapter& adapter) {
-  wgpu::AdapterProperties properties;
-  adapter.GetProperties(&properties);
-  std::cerr << AdapterPropertiesToString(properties) << std::endl;
+void DumpAdapterInfo(wgpu::Adapter& adapter) {
+  wgpu::AdapterInfo info;
+  adapter.GetInfo(&info);
+  std::cerr << AdapterInfoToString(info) << std::endl;
 }
 
 void DumpAdapterFeatures(wgpu::Adapter& adapter) {
-  auto feature_count = adapter.EnumerateFeatures(nullptr);
-  std::vector<wgpu::FeatureName> features(feature_count);
-  adapter.EnumerateFeatures(features.data());
+  wgpu::SupportedFeatures f;
+  adapter.GetFeatures(&f);
   std::cerr << "Adapter Extensions:" << std::endl;
-  for (const auto& f : features) {
-    std::cerr << "  " << FeatureNameToString(f) << std::endl;
+  for (size_t i = 0; i < f.featureCount; ++i) {
+    std::cerr << "  " << FeatureNameToString(f.features[i]) << std::endl;
   }
 }
 
@@ -226,18 +338,17 @@ void DumpAdapterLimits(wgpu::Adapter& adapter) {
 }
 
 void DumpAdapter(wgpu::Adapter& adapter) {
-  DumpAdapterProperties(adapter);
+  DumpAdapterInfo(adapter);
   DumpAdapterFeatures(adapter);
   DumpAdapterLimits(adapter);
 }
 
 void DumpDeviceFeatures(wgpu::Device& device) {
-  auto feature_count = device.EnumerateFeatures(nullptr);
-  std::vector<wgpu::FeatureName> features(feature_count);
-  device.EnumerateFeatures(features.data());
+  wgpu::SupportedFeatures f;
+  device.GetFeatures(&f);
   std::cerr << "Device Extensions:" << std::endl;
-  for (const auto& f : features) {
-    std::cerr << "  " << FeatureNameToString(f) << std::endl;
+  for (size_t i = 0; i < f.featureCount; ++i) {
+    std::cerr << "  " << FeatureNameToString(f.features[i]) << std::endl;
   }
 }
 

--- a/src/example_02/dump_utils.h
+++ b/src/example_02/dump_utils.h
@@ -23,13 +23,13 @@ namespace dusk::dump_utils {
 std::string FeatureNameToString(wgpu::FeatureName f);
 std::string AdapterTypeToString(wgpu::AdapterType type);
 std::string BackendTypeToString(wgpu::BackendType type);
-std::string AdapterPropertiesToString(const wgpu::AdapterProperties& props);
+std::string AdapterInfoToString(const wgpu::AdapterInfo& info);
 std::string FormatNumber(uint64_t num);
 
 std::string LimitsToString(const wgpu::Limits& limits,
                            const std::string& indent);
 
-void DumpAdapterProperties(wgpu::Adapter& adapter);
+void DumpAdapterInfo(wgpu::Adapter& adapter);
 void DumpAdapterFeatures(wgpu::Adapter& adapter);
 void DumpAdapterLimits(wgpu::Adapter& adapter);
 void DumpAdapter(wgpu::Adapter& adapter);

--- a/src/example_02/main.cc
+++ b/src/example_02/main.cc
@@ -77,7 +77,7 @@ int main() {
   wgpu::Adapter adapter;
   instance.RequestAdapter(
       nullptr,
-      [](WGPURequestAdapterStatus, WGPUAdapter adapterIn, const char*,
+      [](WGPURequestAdapterStatus, WGPUAdapter adapterIn, WGPUStringView,
          void* userdata) {
         *static_cast<wgpu::Adapter*>(userdata) =
             wgpu::Adapter::Acquire(adapterIn);
@@ -87,11 +87,13 @@ int main() {
   dusk::dump_utils::DumpAdapter(adapter);
 
   // Get device
-  auto device = adapter.CreateDevice();
+  wgpu::DeviceDescriptor deviceDesc;
+  deviceDesc.SetDeviceLostCallback(wgpu::CallbackMode::AllowSpontaneous,
+                                   dusk::cb::DeviceLost);
+  deviceDesc.SetUncapturedErrorCallback(dusk::cb::Error);
+  auto device = adapter.CreateDevice(&deviceDesc);
   device.SetLabel("Primary Device");
 
-  device.SetUncapturedErrorCallback(dusk::cb::Error, nullptr);
-  device.SetDeviceLostCallback(dusk::cb::DeviceLost, nullptr);
   // Logging is enabled as soon as the callback is setup.
   device.SetLoggingCallback(dusk::cb::Logging, nullptr);
 
@@ -100,15 +102,18 @@ int main() {
   // Get surface
   auto surface = wgpu::glfw::CreateSurfaceForWindow(instance, window);
 
-  // Setup swapchain
-  wgpu::SwapChainDescriptor swapchainDesc{
-      .usage = wgpu::TextureUsage::RenderAttachment,
-      .format = wgpu::TextureFormat::BGRA8Unorm,
+  // Set up surface for drawing and presenting
+  wgpu::SurfaceCapabilities capabilities;
+  surface.GetCapabilities(adapter, &capabilities);
+  auto surfaceFormat = capabilities.formats[0];
+  wgpu::SurfaceConfiguration config = {
+      .device = device,
+      .format = surfaceFormat,
       .width = kWidth,
       .height = kHeight,
       .presentMode = wgpu::PresentMode::Mailbox,
   };
-  auto swapchain = device.CreateSwapChain(surface, &swapchainDesc);
+  surface.Configure(&config);
 
   // Create buffers
   auto vertexBuffer = dusk::webgpu::createBufferFromData(
@@ -134,12 +139,13 @@ int main() {
 
   wgpu::VertexBufferLayout vertBufferLayout{
       .arrayStride = 8 * sizeof(float),
+      .stepMode = wgpu::VertexStepMode::Vertex,
       .attributeCount = 2,
       .attributes = vertAttributes,
   };
 
   wgpu::ColorTargetState target{
-      .format = wgpu::TextureFormat::BGRA8Unorm,
+      .format = surfaceFormat,
   };
 
   wgpu::FragmentState fragState{
@@ -169,7 +175,9 @@ int main() {
     encoder.SetLabel("Main command encoder");
 
     {
-      auto backbufferView = swapchain.GetCurrentTextureView();
+      wgpu::SurfaceTexture surfaceTexture;
+      surface.GetCurrentTexture(&surfaceTexture);
+      auto backbufferView = surfaceTexture.texture.CreateView();
       backbufferView.SetLabel("Back Buffer Texture View");
 
       wgpu::RenderPassColorAttachment attachment{
@@ -194,7 +202,7 @@ int main() {
     auto commands = encoder.Finish();
 
     device.GetQueue().Submit(1, &commands);
-    swapchain.Present();
+    surface.Present();
   };
 
   while (!glfwWindowShouldClose(window)) {

--- a/src/example_02/webgpu_helpers.cc
+++ b/src/example_02/webgpu_helpers.cc
@@ -34,8 +34,8 @@ wgpu::Buffer createBufferFromData(const wgpu::Device& device,
 wgpu::ShaderModule createShaderModule(const wgpu::Device& device,
                                       const std::string& label,
                                       const char* src) {
-  wgpu::ShaderModuleWGSLDescriptor wgslDesc;
-  wgslDesc.source = src;
+  wgpu::ShaderSourceWGSL wgslDesc;
+  wgslDesc.code = src;
   wgpu::ShaderModuleDescriptor desc{
       .nextInChain = &wgslDesc,
       .label = label.c_str(),

--- a/src/example_03/callbacks.cc
+++ b/src/example_03/callbacks.cc
@@ -18,40 +18,50 @@
 
 namespace dusk::cb {
 
-void Error(WGPUErrorType type, const char* msg, void*) {
+namespace {
+std::string_view str(const WGPUStringView& s) {
+  return {s.data, s.length};
+}
+}  // anonymous namespace
+
+void Error(const wgpu::Device&, wgpu::ErrorType type, const char* msg) {
   switch (type) {
-    case WGPUErrorType_OutOfMemory:
+    case wgpu::ErrorType::OutOfMemory:
       std::cerr << "[Error] Out Of Memory: " << msg << std::endl;
       abort();
-    case WGPUErrorType_Validation:
+    case wgpu::ErrorType::Validation:
       std::cerr << "[Error Validation: " << msg << std::endl;
       abort();
-    case WGPUErrorType_NoError:
-    case WGPUErrorType_Unknown:
-    case WGPUErrorType_DeviceLost:
-    case WGPUErrorType_Force32:
-    case WGPUErrorType_Internal:
+    case wgpu::ErrorType::NoError:
+    case wgpu::ErrorType::Unknown:
+    case wgpu::ErrorType::DeviceLost:
+    case wgpu::ErrorType::Internal:
       std::cerr << msg << std::endl;
       break;
   }
 }
 
-void DeviceLost(WGPUDeviceLostReason reason, char const* msg, void*) {
+void DeviceLost(const wgpu::Device&,
+                wgpu::DeviceLostReason reason,
+                const char* msg) {
   std::cerr << "[Device Lost]: ";
   switch (reason) {
-    case WGPUDeviceLostReason_Undefined:
+    case wgpu::DeviceLostReason::Unknown:
       std::cerr << "Undefined: " << msg << std::endl;
       break;
-    case WGPUDeviceLostReason_Destroyed:
+    case wgpu::DeviceLostReason::Destroyed:
       std::cerr << "Destroyed: " << msg << std::endl;
       break;
-    case WGPUDeviceLostReason_Force32:
-      std::cerr << "Force32: " << msg << std::endl;
+    case wgpu::DeviceLostReason::InstanceDropped:
+      std::cerr << "InstanceDropped: " << msg << std::endl;
+      break;
+    case wgpu::DeviceLostReason::FailedCreation:
+      std::cerr << "FailedCreation: " << msg << std::endl;
       break;
   }
 }
 
-void Logging(WGPULoggingType type, const char* msg, void*) {
+void Logging(WGPULoggingType type, WGPUStringView msg, void*) {
   switch (type) {
     case WGPULoggingType_Verbose:
       std::cerr << "Log [Verbose]: ";
@@ -69,7 +79,7 @@ void Logging(WGPULoggingType type, const char* msg, void*) {
       std::cerr << "Log [Force32]: ";
       break;
   }
-  std::cerr << msg << std::endl;
+  std::cerr << str(msg) << std::endl;
 }
 
 }  // namespace dusk::cb

--- a/src/example_03/callbacks.h
+++ b/src/example_03/callbacks.h
@@ -18,8 +18,10 @@
 
 namespace dusk::cb {
 
-void Error(WGPUErrorType type, const char* msg, void*);
-void DeviceLost(WGPUDeviceLostReason reason, char const* msg, void*);
-void Logging(WGPULoggingType type, const char* msg, void*);
+void Error(const wgpu::Device&, wgpu::ErrorType type, const char* msg);
+void DeviceLost(const wgpu::Device&,
+                wgpu::DeviceLostReason reason,
+                const char* msg);
+void Logging(WGPULoggingType type, WGPUStringView msg, void*);
 
 }  // namespace dusk::cb

--- a/src/example_03/dump_utils.cc
+++ b/src/example_03/dump_utils.cc
@@ -17,9 +17,16 @@
 #include <cassert>
 #include <iostream>
 #include <sstream>
+#include <string_view>
 #include <vector>
 
 namespace dusk::dump_utils {
+
+namespace {
+std::string str(const wgpu::StringView& s) {
+  return {s.data, s.length};
+}
+}  // namespace
 
 std::string FeatureNameToString(wgpu::FeatureName f) {
   switch (f) {
@@ -29,8 +36,6 @@ std::string FeatureNameToString(wgpu::FeatureName f) {
       return "Depth32FloatStencil8";
     case wgpu::FeatureName::TimestampQuery:
       return "TimestampQuery";
-    case wgpu::FeatureName::PipelineStatisticsQuery:
-      return "PipelineStatisticsQuery";
     case wgpu::FeatureName::TextureCompressionBC:
       return "TextureCompressionBC";
     case wgpu::FeatureName::TextureCompressionETC2:
@@ -39,26 +44,134 @@ std::string FeatureNameToString(wgpu::FeatureName f) {
       return "TextureCompressionASTC";
     case wgpu::FeatureName::IndirectFirstInstance:
       return "IndirectFirstInstance";
-    case wgpu::FeatureName::DawnShaderFloat16:
-      return "DawnShaderFloat16";
+    case wgpu::FeatureName::ShaderF16:
+      return "ShaderF16";
+    case wgpu::FeatureName::RG11B10UfloatRenderable:
+      return "RG11B10UfloatRenderable";
+    case wgpu::FeatureName::BGRA8UnormStorage:
+      return "BGRA8UnormStorage";
+    case wgpu::FeatureName::Float32Filterable:
+      return "Float32Filterable";
+    case wgpu::FeatureName::Float32Blendable:
+      return "Float32Blendable";
+    case wgpu::FeatureName::Subgroups:
+      return "Subgroups";
+    case wgpu::FeatureName::SubgroupsF16:
+      return "SubgroupsF16";
     case wgpu::FeatureName::DawnInternalUsages:
       return "DawnInternalUsages";
     case wgpu::FeatureName::DawnMultiPlanarFormats:
       return "DawnMultiPlanarFormats";
     case wgpu::FeatureName::DawnNative:
       return "DawnNative";
-    case wgpu::FeatureName::ChromiumExperimentalDp4a:
-      return "ChromiumExperimentalDp4a";
-    case wgpu::FeatureName::TimestampQueryInsidePasses:
-      return "TimestampQueryInsidePasses";
-    case wgpu::FeatureName::ShaderF16:
-      return "ShaderF16";
-    case wgpu::FeatureName::RG11B10UfloatRenderable:
-      return "RG11B10UfloatRenderable";
-    case wgpu::FeatureName::Undefined:
-      break;
+    case wgpu::FeatureName::ChromiumExperimentalTimestampQueryInsidePasses:
+      return "ChromiumExperimentalTimestampQueryInsidePasses";
+    case wgpu::FeatureName::ImplicitDeviceSynchronization:
+      return "ImplicitDeviceSynchronization";
+    case wgpu::FeatureName::ChromiumExperimentalImmediateData:
+      return "ChromiumExperimentalImmediateData";
+    case wgpu::FeatureName::TransientAttachments:
+      return "TransientAttachments";
+    case wgpu::FeatureName::MSAARenderToSingleSampled:
+      return "MSAARenderToSingleSampled";
+    case wgpu::FeatureName::DualSourceBlending:
+      return "DualSourceBlending";
+    case wgpu::FeatureName::D3D11MultithreadProtected:
+      return "D3D11MultithreadProtected";
+    case wgpu::FeatureName::ANGLETextureSharing:
+      return "ANGLETextureSharing";
+    case wgpu::FeatureName::PixelLocalStorageCoherent:
+      return "PixelLocalStorageCoherent";
+    case wgpu::FeatureName::PixelLocalStorageNonCoherent:
+      return "PixelLocalStorageNonCoherent";
+    case wgpu::FeatureName::Unorm16TextureFormats:
+      return "Unorm16TextureFormats";
+    case wgpu::FeatureName::Snorm16TextureFormats:
+      return "Snorm16TextureFormats";
+    case wgpu::FeatureName::MultiPlanarFormatExtendedUsages:
+      return "MultiPlanarFormatExtendedUsages";
+    case wgpu::FeatureName::MultiPlanarFormatP010:
+      return "MultiPlanarFormatP010";
+    case wgpu::FeatureName::HostMappedPointer:
+      return "HostMappedPointer";
+    case wgpu::FeatureName::MultiPlanarRenderTargets:
+      return "MultiPlanarRenderTargets";
+    case wgpu::FeatureName::MultiPlanarFormatNv12a:
+      return "MultiPlanarFormatNv12a";
+    case wgpu::FeatureName::FramebufferFetch:
+      return "FramebufferFetch";
+    case wgpu::FeatureName::BufferMapExtendedUsages:
+      return "BufferMapExtendedUsages";
+    case wgpu::FeatureName::AdapterPropertiesMemoryHeaps:
+      return "AdapterPropertiesMemoryHeaps";
+    case wgpu::FeatureName::AdapterPropertiesD3D:
+      return "AdapterPropertiesD3D";
+    case wgpu::FeatureName::AdapterPropertiesVk:
+      return "AdapterPropertiesVk";
+    case wgpu::FeatureName::R8UnormStorage:
+      return "R8UnormStorage";
+    case wgpu::FeatureName::FormatCapabilities:
+      return "FormatCapabilities";
+    case wgpu::FeatureName::DrmFormatCapabilities:
+      return "DrmFormatCapabilities";
+    case wgpu::FeatureName::Norm16TextureFormats:
+      return "Norm16TextureFormats";
+    case wgpu::FeatureName::MultiPlanarFormatNv16:
+      return "MultiPlanarFormatNv16";
+    case wgpu::FeatureName::MultiPlanarFormatNv24:
+      return "MultiPlanarFormatNv24";
+    case wgpu::FeatureName::MultiPlanarFormatP210:
+      return "MultiPlanarFormatP210";
+    case wgpu::FeatureName::MultiPlanarFormatP410:
+      return "MultiPlanarFormatP410";
+    case wgpu::FeatureName::SharedTextureMemoryVkDedicatedAllocation:
+      return "SharedTextureMemoryVkDedicatedAllocation";
+    case wgpu::FeatureName::SharedTextureMemoryAHardwareBuffer:
+      return "SharedTextureMemoryAHardwareBuffer";
+    case wgpu::FeatureName::SharedTextureMemoryDmaBuf:
+      return "SharedTextureMemoryDmaBuf";
+    case wgpu::FeatureName::SharedTextureMemoryOpaqueFD:
+      return "SharedTextureMemoryOpaqueFD";
+    case wgpu::FeatureName::SharedTextureMemoryZirconHandle:
+      return "SharedTextureMemoryZirconHandle";
+    case wgpu::FeatureName::SharedTextureMemoryDXGISharedHandle:
+      return "SharedTextureMemoryDXGISharedHandle";
+    case wgpu::FeatureName::SharedTextureMemoryD3D11Texture2D:
+      return "SharedTextureMemoryD3D11Texture2D";
+    case wgpu::FeatureName::SharedTextureMemoryIOSurface:
+      return "SharedTextureMemoryIOSurface";
+    case wgpu::FeatureName::SharedTextureMemoryEGLImage:
+      return "SharedTextureMemoryEGLImage";
+    case wgpu::FeatureName::SharedFenceVkSemaphoreOpaqueFD:
+      return "SharedFenceVkSemaphoreOpaqueFD";
+    case wgpu::FeatureName::SharedFenceSyncFD:
+      return "SharedFenceSyncFD";
+    case wgpu::FeatureName::SharedFenceVkSemaphoreZirconHandle:
+      return "SharedFenceVkSemaphoreZirconHandle";
+    case wgpu::FeatureName::SharedFenceDXGISharedHandle:
+      return "SharedFenceDXGISharedHandle";
+    case wgpu::FeatureName::SharedFenceMTLSharedEvent:
+      return "SharedFenceMTLSharedEvent";
+    case wgpu::FeatureName::SharedBufferMemoryD3D12Resource:
+      return "SharedBufferMemoryD3D12Resource";
+    case wgpu::FeatureName::StaticSamplers:
+      return "StaticSamplers";
+    case wgpu::FeatureName::YCbCrVulkanSamplers:
+      return "YCbCrVulkanSamplers";
+    case wgpu::FeatureName::ShaderModuleCompilationOptions:
+      return "ShaderModuleCompilationOptions";
+    case wgpu::FeatureName::DawnLoadResolveTexture:
+      return "DawnLoadResolveTexture";
+    case wgpu::FeatureName::DawnPartialLoadResolveTexture:
+      return "DawnPartialLoadResolveTexture";
+    case wgpu::FeatureName::MultiDrawIndirect:
+      return "MultiDrawIndirect";
+    case wgpu::FeatureName::ClipDistances:
+      return "ClipDistances";
+    case wgpu::FeatureName::DawnTexelCopyBufferRowAlignment:
+      return "DawnTexelCopyBufferRowAlignment";
   }
-  return "Undefined";
+  return "Unknown";
 }
 
 std::string AdapterTypeToString(wgpu::AdapterType type) {
@@ -93,23 +206,23 @@ std::string BackendTypeToString(wgpu::BackendType type) {
       return "OpenGL";
     case wgpu::BackendType::OpenGLES:
       return "OpenGLES";
+    case wgpu::BackendType::Undefined:
+      return "Undefined";
   }
   return "unknown";
 }
 
-std::string AdapterPropertiesToString(const wgpu::AdapterProperties& props) {
-  assert(props.nextInChain == nullptr);
+std::string AdapterInfoToString(const wgpu::AdapterInfo& info) {
+  assert(info.nextInChain == nullptr);
 
   std::stringstream out;
-  out << "VendorID: " << props.vendorID << std::endl;
-  out << "Vendor: " << props.vendorName << std::endl;
-  out << "Architecture: " << props.architecture << std::endl;
-  out << "DeviceID: " << props.deviceID << std::endl;
-  out << "Name: " << props.name << std::endl;
-  out << "Driver description: " << props.driverDescription << std::endl;
-  out << "Adapter Type: " << AdapterTypeToString(props.adapterType)
+  out << "Vendor: " << str(info.vendor) << std::endl;
+  out << "Architecture: " << str(info.architecture) << std::endl;
+  out << "Device: " << str(info.device) << std::endl;
+  out << "Description: " << str(info.description) << std::endl;
+  out << "Adapter Type: " << AdapterTypeToString(info.adapterType)
       << std::endl;
-  out << "Backend Type: " << BackendTypeToString(props.backendType)
+  out << "Backend Type: " << BackendTypeToString(info.backendType)
       << std::endl;
   return out.str();
 }
@@ -201,19 +314,18 @@ std::string LimitsToString(const wgpu::Limits& limits,
   return out.str();
 }
 
-void DumpAdapterProperties(wgpu::Adapter& adapter) {
-  wgpu::AdapterProperties properties;
-  adapter.GetProperties(&properties);
-  std::cerr << AdapterPropertiesToString(properties) << std::endl;
+void DumpAdapterInfo(wgpu::Adapter& adapter) {
+  wgpu::AdapterInfo info;
+  adapter.GetInfo(&info);
+  std::cerr << AdapterInfoToString(info) << std::endl;
 }
 
 void DumpAdapterFeatures(wgpu::Adapter& adapter) {
-  auto feature_count = adapter.EnumerateFeatures(nullptr);
-  std::vector<wgpu::FeatureName> features(feature_count);
-  adapter.EnumerateFeatures(features.data());
+  wgpu::SupportedFeatures f;
+  adapter.GetFeatures(&f);
   std::cerr << "Adapter Extensions:" << std::endl;
-  for (const auto& f : features) {
-    std::cerr << "  " << FeatureNameToString(f) << std::endl;
+  for (size_t i = 0; i < f.featureCount; ++i) {
+    std::cerr << "  " << FeatureNameToString(f.features[i]) << std::endl;
   }
 }
 
@@ -226,18 +338,17 @@ void DumpAdapterLimits(wgpu::Adapter& adapter) {
 }
 
 void DumpAdapter(wgpu::Adapter& adapter) {
-  DumpAdapterProperties(adapter);
+  DumpAdapterInfo(adapter);
   DumpAdapterFeatures(adapter);
   DumpAdapterLimits(adapter);
 }
 
 void DumpDeviceFeatures(wgpu::Device& device) {
-  auto feature_count = device.EnumerateFeatures(nullptr);
-  std::vector<wgpu::FeatureName> features(feature_count);
-  device.EnumerateFeatures(features.data());
+  wgpu::SupportedFeatures f;
+  device.GetFeatures(&f);
   std::cerr << "Device Extensions:" << std::endl;
-  for (const auto& f : features) {
-    std::cerr << "  " << FeatureNameToString(f) << std::endl;
+  for (size_t i = 0; i < f.featureCount; ++i) {
+    std::cerr << "  " << FeatureNameToString(f.features[i]) << std::endl;
   }
 }
 

--- a/src/example_03/dump_utils.h
+++ b/src/example_03/dump_utils.h
@@ -23,13 +23,13 @@ namespace dusk::dump_utils {
 std::string FeatureNameToString(wgpu::FeatureName f);
 std::string AdapterTypeToString(wgpu::AdapterType type);
 std::string BackendTypeToString(wgpu::BackendType type);
-std::string AdapterPropertiesToString(const wgpu::AdapterProperties& props);
+std::string AdapterInfoToString(const wgpu::AdapterInfo& info);
 std::string FormatNumber(uint64_t num);
 
 std::string LimitsToString(const wgpu::Limits& limits,
                            const std::string& indent);
 
-void DumpAdapterProperties(wgpu::Adapter& adapter);
+void DumpAdapterInfo(wgpu::Adapter& adapter);
 void DumpAdapterFeatures(wgpu::Adapter& adapter);
 void DumpAdapterLimits(wgpu::Adapter& adapter);
 void DumpAdapter(wgpu::Adapter& adapter);

--- a/src/example_03/webgpu_helpers.cc
+++ b/src/example_03/webgpu_helpers.cc
@@ -34,8 +34,8 @@ wgpu::Buffer createBufferFromData(const wgpu::Device& device,
 wgpu::ShaderModule createShaderModule(const wgpu::Device& device,
                                       const std::string& label,
                                       const char* src) {
-  wgpu::ShaderModuleWGSLDescriptor wgslDesc;
-  wgslDesc.source = src;
+  wgpu::ShaderSourceWGSL wgslDesc;
+  wgslDesc.code = src;
   wgpu::ShaderModuleDescriptor desc{
       .nextInChain = &wgslDesc,
       .label = label.c_str(),

--- a/src/example_04/callbacks.cc
+++ b/src/example_04/callbacks.cc
@@ -18,40 +18,50 @@
 
 namespace dusk::cb {
 
-void Error(WGPUErrorType type, const char* msg, void*) {
+namespace {
+std::string_view str(const WGPUStringView& s) {
+  return {s.data, s.length};
+}
+}  // anonymous namespace
+
+void Error(const wgpu::Device&, wgpu::ErrorType type, const char* msg) {
   switch (type) {
-    case WGPUErrorType_OutOfMemory:
-      std::cerr << "[Unhandled Error] Out Of Memory: " << msg << std::endl;
+    case wgpu::ErrorType::OutOfMemory:
+      std::cerr << "[Error] Out Of Memory: " << msg << std::endl;
       abort();
-    case WGPUErrorType_Validation:
-      std::cerr << "[Unhandled Error] Validation: " << msg << std::endl;
+    case wgpu::ErrorType::Validation:
+      std::cerr << "[Error Validation: " << msg << std::endl;
       abort();
-    case WGPUErrorType_NoError:
-    case WGPUErrorType_Unknown:
-    case WGPUErrorType_DeviceLost:
-    case WGPUErrorType_Force32:
-    case WGPUErrorType_Internal:
+    case wgpu::ErrorType::NoError:
+    case wgpu::ErrorType::Unknown:
+    case wgpu::ErrorType::DeviceLost:
+    case wgpu::ErrorType::Internal:
       std::cerr << msg << std::endl;
       break;
   }
 }
 
-void DeviceLost(WGPUDeviceLostReason reason, char const* msg, void*) {
+void DeviceLost(const wgpu::Device&,
+                wgpu::DeviceLostReason reason,
+                const char* msg) {
   std::cerr << "[Device Lost]: ";
   switch (reason) {
-    case WGPUDeviceLostReason_Undefined:
+    case wgpu::DeviceLostReason::Unknown:
       std::cerr << "Undefined: " << msg << std::endl;
       break;
-    case WGPUDeviceLostReason_Destroyed:
+    case wgpu::DeviceLostReason::Destroyed:
       std::cerr << "Destroyed: " << msg << std::endl;
       break;
-    case WGPUDeviceLostReason_Force32:
-      std::cerr << "Force32: " << msg << std::endl;
+    case wgpu::DeviceLostReason::InstanceDropped:
+      std::cerr << "InstanceDropped: " << msg << std::endl;
+      break;
+    case wgpu::DeviceLostReason::FailedCreation:
+      std::cerr << "FailedCreation: " << msg << std::endl;
       break;
   }
 }
 
-void Logging(WGPULoggingType type, const char* msg, void*) {
+void Logging(WGPULoggingType type, WGPUStringView msg, void*) {
   switch (type) {
     case WGPULoggingType_Verbose:
       std::cerr << "Log [Verbose]: ";
@@ -69,7 +79,7 @@ void Logging(WGPULoggingType type, const char* msg, void*) {
       std::cerr << "Log [Force32]: ";
       break;
   }
-  std::cerr << msg << std::endl;
+  std::cerr << str(msg) << std::endl;
 }
 
 }  // namespace dusk::cb

--- a/src/example_04/callbacks.h
+++ b/src/example_04/callbacks.h
@@ -18,8 +18,10 @@
 
 namespace dusk::cb {
 
-void Error(WGPUErrorType type, const char* msg, void*);
-void DeviceLost(WGPUDeviceLostReason reason, char const* msg, void*);
-void Logging(WGPULoggingType type, const char* msg, void*);
+void Error(const wgpu::Device&, wgpu::ErrorType type, const char* msg);
+void DeviceLost(const wgpu::Device&,
+                wgpu::DeviceLostReason reason,
+                const char* msg);
+void Logging(WGPULoggingType type, WGPUStringView msg, void*);
 
 }  // namespace dusk::cb

--- a/src/example_04/dump_utils.cc
+++ b/src/example_04/dump_utils.cc
@@ -17,9 +17,16 @@
 #include <cassert>
 #include <iostream>
 #include <sstream>
+#include <string_view>
 #include <vector>
 
 namespace dusk::dump_utils {
+
+namespace {
+std::string str(const wgpu::StringView& s) {
+  return {s.data, s.length};
+}
+}  // namespace
 
 std::string FeatureNameToString(wgpu::FeatureName f) {
   switch (f) {
@@ -29,8 +36,6 @@ std::string FeatureNameToString(wgpu::FeatureName f) {
       return "Depth32FloatStencil8";
     case wgpu::FeatureName::TimestampQuery:
       return "TimestampQuery";
-    case wgpu::FeatureName::PipelineStatisticsQuery:
-      return "PipelineStatisticsQuery";
     case wgpu::FeatureName::TextureCompressionBC:
       return "TextureCompressionBC";
     case wgpu::FeatureName::TextureCompressionETC2:
@@ -39,26 +44,134 @@ std::string FeatureNameToString(wgpu::FeatureName f) {
       return "TextureCompressionASTC";
     case wgpu::FeatureName::IndirectFirstInstance:
       return "IndirectFirstInstance";
-    case wgpu::FeatureName::DawnShaderFloat16:
-      return "DawnShaderFloat16";
+    case wgpu::FeatureName::ShaderF16:
+      return "ShaderF16";
+    case wgpu::FeatureName::RG11B10UfloatRenderable:
+      return "RG11B10UfloatRenderable";
+    case wgpu::FeatureName::BGRA8UnormStorage:
+      return "BGRA8UnormStorage";
+    case wgpu::FeatureName::Float32Filterable:
+      return "Float32Filterable";
+    case wgpu::FeatureName::Float32Blendable:
+      return "Float32Blendable";
+    case wgpu::FeatureName::Subgroups:
+      return "Subgroups";
+    case wgpu::FeatureName::SubgroupsF16:
+      return "SubgroupsF16";
     case wgpu::FeatureName::DawnInternalUsages:
       return "DawnInternalUsages";
     case wgpu::FeatureName::DawnMultiPlanarFormats:
       return "DawnMultiPlanarFormats";
     case wgpu::FeatureName::DawnNative:
       return "DawnNative";
-    case wgpu::FeatureName::ChromiumExperimentalDp4a:
-      return "ChromiumExperimentalDp4a";
-    case wgpu::FeatureName::TimestampQueryInsidePasses:
-      return "TimestampQueryInsidePasses";
-    case wgpu::FeatureName::ShaderF16:
-      return "ShaderF16";
-    case wgpu::FeatureName::RG11B10UfloatRenderable:
-      return "RG11B10UfloatRenderable";
-    case wgpu::FeatureName::Undefined:
-      break;
+    case wgpu::FeatureName::ChromiumExperimentalTimestampQueryInsidePasses:
+      return "ChromiumExperimentalTimestampQueryInsidePasses";
+    case wgpu::FeatureName::ImplicitDeviceSynchronization:
+      return "ImplicitDeviceSynchronization";
+    case wgpu::FeatureName::ChromiumExperimentalImmediateData:
+      return "ChromiumExperimentalImmediateData";
+    case wgpu::FeatureName::TransientAttachments:
+      return "TransientAttachments";
+    case wgpu::FeatureName::MSAARenderToSingleSampled:
+      return "MSAARenderToSingleSampled";
+    case wgpu::FeatureName::DualSourceBlending:
+      return "DualSourceBlending";
+    case wgpu::FeatureName::D3D11MultithreadProtected:
+      return "D3D11MultithreadProtected";
+    case wgpu::FeatureName::ANGLETextureSharing:
+      return "ANGLETextureSharing";
+    case wgpu::FeatureName::PixelLocalStorageCoherent:
+      return "PixelLocalStorageCoherent";
+    case wgpu::FeatureName::PixelLocalStorageNonCoherent:
+      return "PixelLocalStorageNonCoherent";
+    case wgpu::FeatureName::Unorm16TextureFormats:
+      return "Unorm16TextureFormats";
+    case wgpu::FeatureName::Snorm16TextureFormats:
+      return "Snorm16TextureFormats";
+    case wgpu::FeatureName::MultiPlanarFormatExtendedUsages:
+      return "MultiPlanarFormatExtendedUsages";
+    case wgpu::FeatureName::MultiPlanarFormatP010:
+      return "MultiPlanarFormatP010";
+    case wgpu::FeatureName::HostMappedPointer:
+      return "HostMappedPointer";
+    case wgpu::FeatureName::MultiPlanarRenderTargets:
+      return "MultiPlanarRenderTargets";
+    case wgpu::FeatureName::MultiPlanarFormatNv12a:
+      return "MultiPlanarFormatNv12a";
+    case wgpu::FeatureName::FramebufferFetch:
+      return "FramebufferFetch";
+    case wgpu::FeatureName::BufferMapExtendedUsages:
+      return "BufferMapExtendedUsages";
+    case wgpu::FeatureName::AdapterPropertiesMemoryHeaps:
+      return "AdapterPropertiesMemoryHeaps";
+    case wgpu::FeatureName::AdapterPropertiesD3D:
+      return "AdapterPropertiesD3D";
+    case wgpu::FeatureName::AdapterPropertiesVk:
+      return "AdapterPropertiesVk";
+    case wgpu::FeatureName::R8UnormStorage:
+      return "R8UnormStorage";
+    case wgpu::FeatureName::FormatCapabilities:
+      return "FormatCapabilities";
+    case wgpu::FeatureName::DrmFormatCapabilities:
+      return "DrmFormatCapabilities";
+    case wgpu::FeatureName::Norm16TextureFormats:
+      return "Norm16TextureFormats";
+    case wgpu::FeatureName::MultiPlanarFormatNv16:
+      return "MultiPlanarFormatNv16";
+    case wgpu::FeatureName::MultiPlanarFormatNv24:
+      return "MultiPlanarFormatNv24";
+    case wgpu::FeatureName::MultiPlanarFormatP210:
+      return "MultiPlanarFormatP210";
+    case wgpu::FeatureName::MultiPlanarFormatP410:
+      return "MultiPlanarFormatP410";
+    case wgpu::FeatureName::SharedTextureMemoryVkDedicatedAllocation:
+      return "SharedTextureMemoryVkDedicatedAllocation";
+    case wgpu::FeatureName::SharedTextureMemoryAHardwareBuffer:
+      return "SharedTextureMemoryAHardwareBuffer";
+    case wgpu::FeatureName::SharedTextureMemoryDmaBuf:
+      return "SharedTextureMemoryDmaBuf";
+    case wgpu::FeatureName::SharedTextureMemoryOpaqueFD:
+      return "SharedTextureMemoryOpaqueFD";
+    case wgpu::FeatureName::SharedTextureMemoryZirconHandle:
+      return "SharedTextureMemoryZirconHandle";
+    case wgpu::FeatureName::SharedTextureMemoryDXGISharedHandle:
+      return "SharedTextureMemoryDXGISharedHandle";
+    case wgpu::FeatureName::SharedTextureMemoryD3D11Texture2D:
+      return "SharedTextureMemoryD3D11Texture2D";
+    case wgpu::FeatureName::SharedTextureMemoryIOSurface:
+      return "SharedTextureMemoryIOSurface";
+    case wgpu::FeatureName::SharedTextureMemoryEGLImage:
+      return "SharedTextureMemoryEGLImage";
+    case wgpu::FeatureName::SharedFenceVkSemaphoreOpaqueFD:
+      return "SharedFenceVkSemaphoreOpaqueFD";
+    case wgpu::FeatureName::SharedFenceSyncFD:
+      return "SharedFenceSyncFD";
+    case wgpu::FeatureName::SharedFenceVkSemaphoreZirconHandle:
+      return "SharedFenceVkSemaphoreZirconHandle";
+    case wgpu::FeatureName::SharedFenceDXGISharedHandle:
+      return "SharedFenceDXGISharedHandle";
+    case wgpu::FeatureName::SharedFenceMTLSharedEvent:
+      return "SharedFenceMTLSharedEvent";
+    case wgpu::FeatureName::SharedBufferMemoryD3D12Resource:
+      return "SharedBufferMemoryD3D12Resource";
+    case wgpu::FeatureName::StaticSamplers:
+      return "StaticSamplers";
+    case wgpu::FeatureName::YCbCrVulkanSamplers:
+      return "YCbCrVulkanSamplers";
+    case wgpu::FeatureName::ShaderModuleCompilationOptions:
+      return "ShaderModuleCompilationOptions";
+    case wgpu::FeatureName::DawnLoadResolveTexture:
+      return "DawnLoadResolveTexture";
+    case wgpu::FeatureName::DawnPartialLoadResolveTexture:
+      return "DawnPartialLoadResolveTexture";
+    case wgpu::FeatureName::MultiDrawIndirect:
+      return "MultiDrawIndirect";
+    case wgpu::FeatureName::ClipDistances:
+      return "ClipDistances";
+    case wgpu::FeatureName::DawnTexelCopyBufferRowAlignment:
+      return "DawnTexelCopyBufferRowAlignment";
   }
-  return "Undefined";
+  return "Unknown";
 }
 
 std::string AdapterTypeToString(wgpu::AdapterType type) {
@@ -93,23 +206,23 @@ std::string BackendTypeToString(wgpu::BackendType type) {
       return "OpenGL";
     case wgpu::BackendType::OpenGLES:
       return "OpenGLES";
+    case wgpu::BackendType::Undefined:
+      return "Undefined";
   }
   return "unknown";
 }
 
-std::string AdapterPropertiesToString(const wgpu::AdapterProperties& props) {
-  assert(props.nextInChain == nullptr);
+std::string AdapterInfoToString(const wgpu::AdapterInfo& info) {
+  assert(info.nextInChain == nullptr);
 
   std::stringstream out;
-  out << "VendorID: " << props.vendorID << std::endl;
-  out << "Vendor: " << props.vendorName << std::endl;
-  out << "Architecture: " << props.architecture << std::endl;
-  out << "DeviceID: " << props.deviceID << std::endl;
-  out << "Name: " << props.name << std::endl;
-  out << "Driver description: " << props.driverDescription << std::endl;
-  out << "Adapter Type: " << AdapterTypeToString(props.adapterType)
+  out << "Vendor: " << str(info.vendor) << std::endl;
+  out << "Architecture: " << str(info.architecture) << std::endl;
+  out << "Device: " << str(info.device) << std::endl;
+  out << "Description: " << str(info.description) << std::endl;
+  out << "Adapter Type: " << AdapterTypeToString(info.adapterType)
       << std::endl;
-  out << "Backend Type: " << BackendTypeToString(props.backendType)
+  out << "Backend Type: " << BackendTypeToString(info.backendType)
       << std::endl;
   return out.str();
 }
@@ -201,19 +314,18 @@ std::string LimitsToString(const wgpu::Limits& limits,
   return out.str();
 }
 
-void DumpAdapterProperties(wgpu::Adapter& adapter) {
-  wgpu::AdapterProperties properties;
-  adapter.GetProperties(&properties);
-  std::cerr << AdapterPropertiesToString(properties) << std::endl;
+void DumpAdapterInfo(wgpu::Adapter& adapter) {
+  wgpu::AdapterInfo info;
+  adapter.GetInfo(&info);
+  std::cerr << AdapterInfoToString(info) << std::endl;
 }
 
 void DumpAdapterFeatures(wgpu::Adapter& adapter) {
-  auto feature_count = adapter.EnumerateFeatures(nullptr);
-  std::vector<wgpu::FeatureName> features(feature_count);
-  adapter.EnumerateFeatures(features.data());
+  wgpu::SupportedFeatures f;
+  adapter.GetFeatures(&f);
   std::cerr << "Adapter Extensions:" << std::endl;
-  for (const auto& f : features) {
-    std::cerr << "  " << FeatureNameToString(f) << std::endl;
+  for (size_t i = 0; i < f.featureCount; ++i) {
+    std::cerr << "  " << FeatureNameToString(f.features[i]) << std::endl;
   }
 }
 
@@ -226,18 +338,17 @@ void DumpAdapterLimits(wgpu::Adapter& adapter) {
 }
 
 void DumpAdapter(wgpu::Adapter& adapter) {
-  DumpAdapterProperties(adapter);
+  DumpAdapterInfo(adapter);
   DumpAdapterFeatures(adapter);
   DumpAdapterLimits(adapter);
 }
 
 void DumpDeviceFeatures(wgpu::Device& device) {
-  auto feature_count = device.EnumerateFeatures(nullptr);
-  std::vector<wgpu::FeatureName> features(feature_count);
-  device.EnumerateFeatures(features.data());
+  wgpu::SupportedFeatures f;
+  device.GetFeatures(&f);
   std::cerr << "Device Extensions:" << std::endl;
-  for (const auto& f : features) {
-    std::cerr << "  " << FeatureNameToString(f) << std::endl;
+  for (size_t i = 0; i < f.featureCount; ++i) {
+    std::cerr << "  " << FeatureNameToString(f.features[i]) << std::endl;
   }
 }
 

--- a/src/example_04/dump_utils.h
+++ b/src/example_04/dump_utils.h
@@ -23,13 +23,13 @@ namespace dusk::dump_utils {
 std::string FeatureNameToString(wgpu::FeatureName f);
 std::string AdapterTypeToString(wgpu::AdapterType type);
 std::string BackendTypeToString(wgpu::BackendType type);
-std::string AdapterPropertiesToString(const wgpu::AdapterProperties& props);
+std::string AdapterInfoToString(const wgpu::AdapterInfo& info);
 std::string FormatNumber(uint64_t num);
 
 std::string LimitsToString(const wgpu::Limits& limits,
                            const std::string& indent);
 
-void DumpAdapterProperties(wgpu::Adapter& adapter);
+void DumpAdapterInfo(wgpu::Adapter& adapter);
 void DumpAdapterFeatures(wgpu::Adapter& adapter);
 void DumpAdapterLimits(wgpu::Adapter& adapter);
 void DumpAdapter(wgpu::Adapter& adapter);

--- a/src/example_04/main.cc
+++ b/src/example_04/main.cc
@@ -136,7 +136,7 @@ int main() {
   wgpu::Adapter adapter;
   instance.RequestAdapter(
       nullptr,
-      [](WGPURequestAdapterStatus, WGPUAdapter adapterIn, const char*,
+      [](WGPURequestAdapterStatus, WGPUAdapter adapterIn, WGPUStringView,
          void* userdata) {
         *static_cast<wgpu::Adapter*>(userdata) =
             wgpu::Adapter::Acquire(adapterIn);
@@ -146,11 +146,13 @@ int main() {
   dusk::dump_utils::DumpAdapter(adapter);
 
   // Get device
-  auto device = adapter.CreateDevice();
+  wgpu::DeviceDescriptor deviceDesc;
+  deviceDesc.SetDeviceLostCallback(wgpu::CallbackMode::AllowSpontaneous,
+                                   dusk::cb::DeviceLost);
+  deviceDesc.SetUncapturedErrorCallback(dusk::cb::Error);
+  auto device = adapter.CreateDevice(&deviceDesc);
   device.SetLabel("Primary Device");
 
-  device.SetUncapturedErrorCallback(dusk::cb::Error, nullptr);
-  device.SetDeviceLostCallback(dusk::cb::DeviceLost, nullptr);
   // Logging is enabled as soon as the callback is setup.
   device.SetLoggingCallback(dusk::cb::Logging, nullptr);
 
@@ -159,15 +161,18 @@ int main() {
   // Get surface
   auto surface = wgpu::glfw::CreateSurfaceForWindow(instance, window);
 
-  // Setup swapchain
-  wgpu::SwapChainDescriptor swapchainDesc{
-      .usage = wgpu::TextureUsage::RenderAttachment,
-      .format = wgpu::TextureFormat::BGRA8Unorm,
+  // Setup surface for drawing and presenting
+  wgpu::SurfaceCapabilities capabilities;
+  surface.GetCapabilities(adapter, &capabilities);
+  auto surfaceFormat = capabilities.formats[0];
+  wgpu::SurfaceConfiguration config = {
+      .device = device,
+      .format = surfaceFormat,
       .width = kWidth,
       .height = kHeight,
       .presentMode = wgpu::PresentMode::Mailbox,
   };
-  auto swapchain = device.CreateSwapChain(surface, &swapchainDesc);
+  surface.Configure(&config);
 
   // Create buffers
   auto vertexBuffer = dusk::webgpu::createBufferFromData(
@@ -193,12 +198,13 @@ int main() {
 
   wgpu::VertexBufferLayout vertBufferLayout{
       .arrayStride = kCubeDataStride * sizeof(float),
+      .stepMode = wgpu::VertexStepMode::Vertex,
       .attributeCount = 2,
       .attributes = vertAttributes,
   };
 
   wgpu::ColorTargetState target{
-      .format = wgpu::TextureFormat::BGRA8Unorm,
+      .format = surfaceFormat,
   };
 
   wgpu::FragmentState fragState{
@@ -313,7 +319,9 @@ int main() {
     encoder.SetLabel("Main Command Encoder");
 
     {
-      auto backbufferView = swapchain.GetCurrentTextureView();
+      wgpu::SurfaceTexture surfaceTexture;
+      surface.GetCurrentTexture(&surfaceTexture);
+      auto backbufferView = surfaceTexture.texture.CreateView();
       backbufferView.SetLabel("Back Buffer Texture View");
 
       attachment.view = backbufferView;
@@ -328,7 +336,7 @@ int main() {
     auto commands = encoder.Finish();
 
     device.GetQueue().Submit(1, &commands);
-    swapchain.Present();
+    surface.Present();
   };
 
   auto start = std::chrono::time_point_cast<std::chrono::seconds>(

--- a/src/example_04/webgpu_helpers.cc
+++ b/src/example_04/webgpu_helpers.cc
@@ -41,8 +41,8 @@ wgpu::Buffer createBufferFromData(const wgpu::Device& device,
 wgpu::ShaderModule createShaderModule(const wgpu::Device& device,
                                       const std::string& label,
                                       const char* src) {
-  wgpu::ShaderModuleWGSLDescriptor wgslDesc;
-  wgslDesc.source = src;
+  wgpu::ShaderSourceWGSL wgslDesc;
+  wgslDesc.code = src;
 
   wgpu::ShaderModuleDescriptor desc{
       .nextInChain = &wgslDesc,

--- a/src/example_05/callbacks.cc
+++ b/src/example_05/callbacks.cc
@@ -18,40 +18,50 @@
 
 namespace dusk::cb {
 
-void Error(WGPUErrorType type, const char* msg, void*) {
+namespace {
+std::string_view str(const WGPUStringView& s) {
+  return {s.data, s.length};
+}
+}  // anonymous namespace
+
+void Error(const wgpu::Device&, wgpu::ErrorType type, const char* msg) {
   switch (type) {
-    case WGPUErrorType_OutOfMemory:
-      std::cerr << "[Unhandled Error] Out Of Memory: " << msg << std::endl;
+    case wgpu::ErrorType::OutOfMemory:
+      std::cerr << "[Error] Out Of Memory: " << msg << std::endl;
       abort();
-    case WGPUErrorType_Validation:
-      std::cerr << "[Unhandled Error] Validation: " << msg << std::endl;
+    case wgpu::ErrorType::Validation:
+      std::cerr << "[Error Validation: " << msg << std::endl;
       abort();
-    case WGPUErrorType_NoError:
-    case WGPUErrorType_Unknown:
-    case WGPUErrorType_DeviceLost:
-    case WGPUErrorType_Force32:
-    case WGPUErrorType_Internal:
+    case wgpu::ErrorType::NoError:
+    case wgpu::ErrorType::Unknown:
+    case wgpu::ErrorType::DeviceLost:
+    case wgpu::ErrorType::Internal:
       std::cerr << msg << std::endl;
       break;
   }
 }
 
-void DeviceLost(WGPUDeviceLostReason reason, char const* msg, void*) {
+void DeviceLost(const wgpu::Device&,
+                wgpu::DeviceLostReason reason,
+                const char* msg) {
   std::cerr << "[Device Lost]: ";
   switch (reason) {
-    case WGPUDeviceLostReason_Undefined:
+    case wgpu::DeviceLostReason::Unknown:
       std::cerr << "Undefined: " << msg << std::endl;
       break;
-    case WGPUDeviceLostReason_Destroyed:
+    case wgpu::DeviceLostReason::Destroyed:
       std::cerr << "Destroyed: " << msg << std::endl;
       break;
-    case WGPUDeviceLostReason_Force32:
-      std::cerr << "Force32: " << msg << std::endl;
+    case wgpu::DeviceLostReason::InstanceDropped:
+      std::cerr << "InstanceDropped: " << msg << std::endl;
+      break;
+    case wgpu::DeviceLostReason::FailedCreation:
+      std::cerr << "FailedCreation: " << msg << std::endl;
       break;
   }
 }
 
-void Logging(WGPULoggingType type, const char* msg, void*) {
+void Logging(WGPULoggingType type, WGPUStringView msg, void*) {
   switch (type) {
     case WGPULoggingType_Verbose:
       std::cerr << "Log [Verbose]: ";
@@ -69,7 +79,7 @@ void Logging(WGPULoggingType type, const char* msg, void*) {
       std::cerr << "Log [Force32]: ";
       break;
   }
-  std::cerr << msg << std::endl;
+  std::cerr << str(msg) << std::endl;
 }
 
 }  // namespace dusk::cb

--- a/src/example_05/callbacks.h
+++ b/src/example_05/callbacks.h
@@ -18,8 +18,10 @@
 
 namespace dusk::cb {
 
-void Error(WGPUErrorType type, const char* msg, void*);
-void DeviceLost(WGPUDeviceLostReason reason, char const* msg, void*);
-void Logging(WGPULoggingType type, const char* msg, void*);
+void Error(const wgpu::Device&, wgpu::ErrorType type, const char* msg);
+void DeviceLost(const wgpu::Device&,
+                wgpu::DeviceLostReason reason,
+                const char* msg);
+void Logging(WGPULoggingType type, WGPUStringView msg, void*);
 
 }  // namespace dusk::cb

--- a/src/example_05/dump_utils.cc
+++ b/src/example_05/dump_utils.cc
@@ -17,9 +17,16 @@
 #include <cassert>
 #include <iostream>
 #include <sstream>
+#include <string_view>
 #include <vector>
 
 namespace dusk::dump_utils {
+
+namespace {
+std::string str(const wgpu::StringView& s) {
+  return {s.data, s.length};
+}
+}  // namespace
 
 std::string FeatureNameToString(wgpu::FeatureName f) {
   switch (f) {
@@ -29,8 +36,6 @@ std::string FeatureNameToString(wgpu::FeatureName f) {
       return "Depth32FloatStencil8";
     case wgpu::FeatureName::TimestampQuery:
       return "TimestampQuery";
-    case wgpu::FeatureName::PipelineStatisticsQuery:
-      return "PipelineStatisticsQuery";
     case wgpu::FeatureName::TextureCompressionBC:
       return "TextureCompressionBC";
     case wgpu::FeatureName::TextureCompressionETC2:
@@ -39,26 +44,134 @@ std::string FeatureNameToString(wgpu::FeatureName f) {
       return "TextureCompressionASTC";
     case wgpu::FeatureName::IndirectFirstInstance:
       return "IndirectFirstInstance";
-    case wgpu::FeatureName::DawnShaderFloat16:
-      return "DawnShaderFloat16";
+    case wgpu::FeatureName::ShaderF16:
+      return "ShaderF16";
+    case wgpu::FeatureName::RG11B10UfloatRenderable:
+      return "RG11B10UfloatRenderable";
+    case wgpu::FeatureName::BGRA8UnormStorage:
+      return "BGRA8UnormStorage";
+    case wgpu::FeatureName::Float32Filterable:
+      return "Float32Filterable";
+    case wgpu::FeatureName::Float32Blendable:
+      return "Float32Blendable";
+    case wgpu::FeatureName::Subgroups:
+      return "Subgroups";
+    case wgpu::FeatureName::SubgroupsF16:
+      return "SubgroupsF16";
     case wgpu::FeatureName::DawnInternalUsages:
       return "DawnInternalUsages";
     case wgpu::FeatureName::DawnMultiPlanarFormats:
       return "DawnMultiPlanarFormats";
     case wgpu::FeatureName::DawnNative:
       return "DawnNative";
-    case wgpu::FeatureName::ChromiumExperimentalDp4a:
-      return "ChromiumExperimentalDp4a";
-    case wgpu::FeatureName::TimestampQueryInsidePasses:
-      return "TimestampQueryInsidePasses";
-    case wgpu::FeatureName::ShaderF16:
-      return "ShaderF16";
-    case wgpu::FeatureName::RG11B10UfloatRenderable:
-      return "RG11B10UfloatRenderable";
-    case wgpu::FeatureName::Undefined:
-      break;
+    case wgpu::FeatureName::ChromiumExperimentalTimestampQueryInsidePasses:
+      return "ChromiumExperimentalTimestampQueryInsidePasses";
+    case wgpu::FeatureName::ImplicitDeviceSynchronization:
+      return "ImplicitDeviceSynchronization";
+    case wgpu::FeatureName::ChromiumExperimentalImmediateData:
+      return "ChromiumExperimentalImmediateData";
+    case wgpu::FeatureName::TransientAttachments:
+      return "TransientAttachments";
+    case wgpu::FeatureName::MSAARenderToSingleSampled:
+      return "MSAARenderToSingleSampled";
+    case wgpu::FeatureName::DualSourceBlending:
+      return "DualSourceBlending";
+    case wgpu::FeatureName::D3D11MultithreadProtected:
+      return "D3D11MultithreadProtected";
+    case wgpu::FeatureName::ANGLETextureSharing:
+      return "ANGLETextureSharing";
+    case wgpu::FeatureName::PixelLocalStorageCoherent:
+      return "PixelLocalStorageCoherent";
+    case wgpu::FeatureName::PixelLocalStorageNonCoherent:
+      return "PixelLocalStorageNonCoherent";
+    case wgpu::FeatureName::Unorm16TextureFormats:
+      return "Unorm16TextureFormats";
+    case wgpu::FeatureName::Snorm16TextureFormats:
+      return "Snorm16TextureFormats";
+    case wgpu::FeatureName::MultiPlanarFormatExtendedUsages:
+      return "MultiPlanarFormatExtendedUsages";
+    case wgpu::FeatureName::MultiPlanarFormatP010:
+      return "MultiPlanarFormatP010";
+    case wgpu::FeatureName::HostMappedPointer:
+      return "HostMappedPointer";
+    case wgpu::FeatureName::MultiPlanarRenderTargets:
+      return "MultiPlanarRenderTargets";
+    case wgpu::FeatureName::MultiPlanarFormatNv12a:
+      return "MultiPlanarFormatNv12a";
+    case wgpu::FeatureName::FramebufferFetch:
+      return "FramebufferFetch";
+    case wgpu::FeatureName::BufferMapExtendedUsages:
+      return "BufferMapExtendedUsages";
+    case wgpu::FeatureName::AdapterPropertiesMemoryHeaps:
+      return "AdapterPropertiesMemoryHeaps";
+    case wgpu::FeatureName::AdapterPropertiesD3D:
+      return "AdapterPropertiesD3D";
+    case wgpu::FeatureName::AdapterPropertiesVk:
+      return "AdapterPropertiesVk";
+    case wgpu::FeatureName::R8UnormStorage:
+      return "R8UnormStorage";
+    case wgpu::FeatureName::FormatCapabilities:
+      return "FormatCapabilities";
+    case wgpu::FeatureName::DrmFormatCapabilities:
+      return "DrmFormatCapabilities";
+    case wgpu::FeatureName::Norm16TextureFormats:
+      return "Norm16TextureFormats";
+    case wgpu::FeatureName::MultiPlanarFormatNv16:
+      return "MultiPlanarFormatNv16";
+    case wgpu::FeatureName::MultiPlanarFormatNv24:
+      return "MultiPlanarFormatNv24";
+    case wgpu::FeatureName::MultiPlanarFormatP210:
+      return "MultiPlanarFormatP210";
+    case wgpu::FeatureName::MultiPlanarFormatP410:
+      return "MultiPlanarFormatP410";
+    case wgpu::FeatureName::SharedTextureMemoryVkDedicatedAllocation:
+      return "SharedTextureMemoryVkDedicatedAllocation";
+    case wgpu::FeatureName::SharedTextureMemoryAHardwareBuffer:
+      return "SharedTextureMemoryAHardwareBuffer";
+    case wgpu::FeatureName::SharedTextureMemoryDmaBuf:
+      return "SharedTextureMemoryDmaBuf";
+    case wgpu::FeatureName::SharedTextureMemoryOpaqueFD:
+      return "SharedTextureMemoryOpaqueFD";
+    case wgpu::FeatureName::SharedTextureMemoryZirconHandle:
+      return "SharedTextureMemoryZirconHandle";
+    case wgpu::FeatureName::SharedTextureMemoryDXGISharedHandle:
+      return "SharedTextureMemoryDXGISharedHandle";
+    case wgpu::FeatureName::SharedTextureMemoryD3D11Texture2D:
+      return "SharedTextureMemoryD3D11Texture2D";
+    case wgpu::FeatureName::SharedTextureMemoryIOSurface:
+      return "SharedTextureMemoryIOSurface";
+    case wgpu::FeatureName::SharedTextureMemoryEGLImage:
+      return "SharedTextureMemoryEGLImage";
+    case wgpu::FeatureName::SharedFenceVkSemaphoreOpaqueFD:
+      return "SharedFenceVkSemaphoreOpaqueFD";
+    case wgpu::FeatureName::SharedFenceSyncFD:
+      return "SharedFenceSyncFD";
+    case wgpu::FeatureName::SharedFenceVkSemaphoreZirconHandle:
+      return "SharedFenceVkSemaphoreZirconHandle";
+    case wgpu::FeatureName::SharedFenceDXGISharedHandle:
+      return "SharedFenceDXGISharedHandle";
+    case wgpu::FeatureName::SharedFenceMTLSharedEvent:
+      return "SharedFenceMTLSharedEvent";
+    case wgpu::FeatureName::SharedBufferMemoryD3D12Resource:
+      return "SharedBufferMemoryD3D12Resource";
+    case wgpu::FeatureName::StaticSamplers:
+      return "StaticSamplers";
+    case wgpu::FeatureName::YCbCrVulkanSamplers:
+      return "YCbCrVulkanSamplers";
+    case wgpu::FeatureName::ShaderModuleCompilationOptions:
+      return "ShaderModuleCompilationOptions";
+    case wgpu::FeatureName::DawnLoadResolveTexture:
+      return "DawnLoadResolveTexture";
+    case wgpu::FeatureName::DawnPartialLoadResolveTexture:
+      return "DawnPartialLoadResolveTexture";
+    case wgpu::FeatureName::MultiDrawIndirect:
+      return "MultiDrawIndirect";
+    case wgpu::FeatureName::ClipDistances:
+      return "ClipDistances";
+    case wgpu::FeatureName::DawnTexelCopyBufferRowAlignment:
+      return "DawnTexelCopyBufferRowAlignment";
   }
-  return "Undefined";
+  return "Unknown";
 }
 
 std::string AdapterTypeToString(wgpu::AdapterType type) {
@@ -93,23 +206,23 @@ std::string BackendTypeToString(wgpu::BackendType type) {
       return "OpenGL";
     case wgpu::BackendType::OpenGLES:
       return "OpenGLES";
+    case wgpu::BackendType::Undefined:
+      return "Undefined";
   }
   return "unknown";
 }
 
-std::string AdapterPropertiesToString(const wgpu::AdapterProperties& props) {
-  assert(props.nextInChain == nullptr);
+std::string AdapterInfoToString(const wgpu::AdapterInfo& info) {
+  assert(info.nextInChain == nullptr);
 
   std::stringstream out;
-  out << "VendorID: " << props.vendorID << std::endl;
-  out << "Vendor: " << props.vendorName << std::endl;
-  out << "Architecture: " << props.architecture << std::endl;
-  out << "DeviceID: " << props.deviceID << std::endl;
-  out << "Name: " << props.name << std::endl;
-  out << "Driver description: " << props.driverDescription << std::endl;
-  out << "Adapter Type: " << AdapterTypeToString(props.adapterType)
+  out << "Vendor: " << str(info.vendor) << std::endl;
+  out << "Architecture: " << str(info.architecture) << std::endl;
+  out << "Device: " << str(info.device) << std::endl;
+  out << "Description: " << str(info.description) << std::endl;
+  out << "Adapter Type: " << AdapterTypeToString(info.adapterType)
       << std::endl;
-  out << "Backend Type: " << BackendTypeToString(props.backendType)
+  out << "Backend Type: " << BackendTypeToString(info.backendType)
       << std::endl;
   return out.str();
 }
@@ -201,19 +314,18 @@ std::string LimitsToString(const wgpu::Limits& limits,
   return out.str();
 }
 
-void DumpAdapterProperties(wgpu::Adapter& adapter) {
-  wgpu::AdapterProperties properties;
-  adapter.GetProperties(&properties);
-  std::cerr << AdapterPropertiesToString(properties) << std::endl;
+void DumpAdapterInfo(wgpu::Adapter& adapter) {
+  wgpu::AdapterInfo info;
+  adapter.GetInfo(&info);
+  std::cerr << AdapterInfoToString(info) << std::endl;
 }
 
 void DumpAdapterFeatures(wgpu::Adapter& adapter) {
-  auto feature_count = adapter.EnumerateFeatures(nullptr);
-  std::vector<wgpu::FeatureName> features(feature_count);
-  adapter.EnumerateFeatures(features.data());
+  wgpu::SupportedFeatures f;
+  adapter.GetFeatures(&f);
   std::cerr << "Adapter Extensions:" << std::endl;
-  for (const auto& f : features) {
-    std::cerr << "  " << FeatureNameToString(f) << std::endl;
+  for (size_t i = 0; i < f.featureCount; ++i) {
+    std::cerr << "  " << FeatureNameToString(f.features[i]) << std::endl;
   }
 }
 
@@ -226,18 +338,17 @@ void DumpAdapterLimits(wgpu::Adapter& adapter) {
 }
 
 void DumpAdapter(wgpu::Adapter& adapter) {
-  DumpAdapterProperties(adapter);
+  DumpAdapterInfo(adapter);
   DumpAdapterFeatures(adapter);
   DumpAdapterLimits(adapter);
 }
 
 void DumpDeviceFeatures(wgpu::Device& device) {
-  auto feature_count = device.EnumerateFeatures(nullptr);
-  std::vector<wgpu::FeatureName> features(feature_count);
-  device.EnumerateFeatures(features.data());
+  wgpu::SupportedFeatures f;
+  device.GetFeatures(&f);
   std::cerr << "Device Extensions:" << std::endl;
-  for (const auto& f : features) {
-    std::cerr << "  " << FeatureNameToString(f) << std::endl;
+  for (size_t i = 0; i < f.featureCount; ++i) {
+    std::cerr << "  " << FeatureNameToString(f.features[i]) << std::endl;
   }
 }
 

--- a/src/example_05/dump_utils.h
+++ b/src/example_05/dump_utils.h
@@ -23,13 +23,13 @@ namespace dusk::dump_utils {
 std::string FeatureNameToString(wgpu::FeatureName f);
 std::string AdapterTypeToString(wgpu::AdapterType type);
 std::string BackendTypeToString(wgpu::BackendType type);
-std::string AdapterPropertiesToString(const wgpu::AdapterProperties& props);
+std::string AdapterInfoToString(const wgpu::AdapterInfo& info);
 std::string FormatNumber(uint64_t num);
 
 std::string LimitsToString(const wgpu::Limits& limits,
                            const std::string& indent);
 
-void DumpAdapterProperties(wgpu::Adapter& adapter);
+void DumpAdapterInfo(wgpu::Adapter& adapter);
 void DumpAdapterFeatures(wgpu::Adapter& adapter);
 void DumpAdapterLimits(wgpu::Adapter& adapter);
 void DumpAdapter(wgpu::Adapter& adapter);

--- a/src/example_05/webgpu_helpers.cc
+++ b/src/example_05/webgpu_helpers.cc
@@ -41,8 +41,8 @@ wgpu::Buffer createBufferFromData(const wgpu::Device& device,
 wgpu::ShaderModule createShaderModule(const wgpu::Device& device,
                                       const std::string& label,
                                       const std::string& src) {
-  wgpu::ShaderModuleWGSLDescriptor wgslDesc;
-  wgslDesc.source = src.c_str();
+  wgpu::ShaderSourceWGSL wgslDesc;
+  wgslDesc.code = src.c_str();
 
   wgpu::ShaderModuleDescriptor desc{
       .nextInChain = &wgslDesc,


### PR DESCRIPTION
- ignore .gcs_entries

- adjust dumping utilities

- wgpu::AdapterProperties is now wgpu::AdapterInfo

- wgpu::Instance::RequestAdapter uses a WGPUStringView instead of const char*

- Error and loss callbacks are given before device creation, in the device descriptor.

- Specify vertex step mode, which for simple cases is Vertex, as opposed to Instance.

- Instead of creating a swapchain object, configure the surface for drawing and presenting.

- Use the format from the surface for rendering and presentation.