### PR TITLE
Move callback code to `common`.

### DIFF
--- a/src/common/callback.cc
+++ b/src/common/callback.cc
@@ -1,0 +1,63 @@
+// Copyright 2025 The Dusk Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/common/callback.h"
+
+#include <cassert>
+#include <print>
+
+#include "src/common/log.h"
+
+namespace dusk::cb {
+
+void adapter_request(wgpu::RequestAdapterStatus status,
+                     wgpu::Adapter a,
+                     wgpu::StringView message,
+                     wgpu::Adapter* data) {
+  if (status != wgpu::RequestAdapterStatus::Success) {
+    std::println(stderr, "Adapter request failed: {}",
+                 std::string_view(message));
+    exit(1);
+  }
+  *data = a;
+}
+
+void device_lost([[maybe_unused]] const wgpu::Device& device,
+                 wgpu::DeviceLostReason reason,
+                 struct wgpu::StringView message) {
+  std::print(stderr, "device lost: {}", dusk::log::to_str(reason));
+  if (message.length > 0) {
+    std::print(stderr, ": {}", std::string_view(message));
+  }
+  std::println(stderr, "");
+}
+
+void uncaptured_error [[noreturn]] ([[maybe_unused]] const wgpu::Device& device,
+                                    wgpu::ErrorType type,
+                                    struct wgpu::StringView message) {
+  std::print(stderr, "uncaptured error: {}", dusk::log::to_str(type));
+  if (message.length > 0) {
+    std::print(stderr, ": {}", std::string_view(message));
+  }
+
+  std::println(stderr, "");
+  assert(false);
+};
+
+void glfw_error [[noreturn]] (int code, const char* message) {
+  std::println(stderr, "GLFW error: {}: {}", code, message);
+  assert(false);
+}
+
+}  // namespace dusk::cb

--- a/src/common/callback.h
+++ b/src/common/callback.h
@@ -1,0 +1,34 @@
+// Copyright 2025 The Dusk Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/common/wgpu.h"
+
+namespace dusk::cb {
+
+void adapter_request(wgpu::RequestAdapterStatus status,
+                     wgpu::Adapter a,
+                     wgpu::StringView message,
+                     wgpu::Adapter* data);
+
+void device_lost([[maybe_unused]] const wgpu::Device& device,
+                 wgpu::DeviceLostReason reason,
+                 struct wgpu::StringView message);
+
+void uncaptured_error [[noreturn]] ([[maybe_unused]] const wgpu::Device& device,
+                                    wgpu::ErrorType type,
+                                    struct wgpu::StringView message);
+
+void glfw_error [[noreturn]] (int code, const char* message);
+
+}  // namespace dusk::cb

--- a/src/example_01/CMakeLists.txt
+++ b/src/example_01/CMakeLists.txt
@@ -15,6 +15,8 @@
 add_executable(dusk_example_01)
 dusk_compile_options(dusk_example_01)
 target_sources(dusk_example_01 PRIVATE
+  ../common/callback.cc
+  ../common/callback.h
   ../common/log.cc
   ../common/log.h
   ../common/wgpu.h

--- a/src/example_02/CMakeLists.txt
+++ b/src/example_02/CMakeLists.txt
@@ -15,6 +15,8 @@
 add_executable(dusk_example_02)
 dusk_compile_options(dusk_example_02)
 target_sources(dusk_example_02 PRIVATE
+  ../common/callback.cc
+  ../common/callback.h
   ../common/glfw.h
   ../common/log.cc
   ../common/log.h

--- a/src/example_03/CMakeLists.txt
+++ b/src/example_03/CMakeLists.txt
@@ -15,6 +15,8 @@
 add_executable(dusk_example_03 ${DUSK_SRCS})
 dusk_compile_options(dusk_example_03)
 target_sources(dusk_example_03 PRIVATE
+  ../common/callback.cc
+  ../common/callback.h
   ../common/glfw.h
   ../common/log.cc
   ../common/log.h

--- a/src/example_03/main.cc
+++ b/src/example_03/main.cc
@@ -15,6 +15,7 @@
 #include <array>
 #include <print>
 
+#include "src/common/callback.h"
 #include "src/common/glfw.h"
 #include "src/common/log.h"
 #include "src/common/webgpu_helpers.h"
@@ -53,50 +54,10 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4f {
 }
 )";
 
-void adapter_request_cb(wgpu::RequestAdapterStatus status,
-                        wgpu::Adapter a,
-                        wgpu::StringView message,
-                        wgpu::Adapter* data) {
-  if (status != wgpu::RequestAdapterStatus::Success) {
-    std::println(stderr, "Adapter request failed: {}",
-                 std::string_view(message));
-    exit(1);
-  }
-  *data = a;
-}
-
-void device_lost_cb([[maybe_unused]] const wgpu::Device& device,
-                    wgpu::DeviceLostReason reason,
-                    struct wgpu::StringView message) {
-  std::print(stderr, "device lost: {}", dusk::log::to_str(reason));
-  if (message.length > 0) {
-    std::print(stderr, ": {}", std::string_view(message));
-  }
-  std::println(stderr, "");
-}
-
-void uncaptured_error_cb
-    [[noreturn]] ([[maybe_unused]] const wgpu::Device& device,
-                  wgpu::ErrorType type,
-                  struct wgpu::StringView message) {
-  std::print(stderr, "uncaptured error: {}", dusk::log::to_str(type));
-  if (message.length > 0) {
-    std::print(stderr, ": {}", std::string_view(message));
-  }
-
-  std::println(stderr, "");
-  assert(false);
-};
-
-void glfw_error_cb [[noreturn]] (int code, const char* message) {
-  std::println(stderr, "GLFW error: {}: {}", code, message);
-  assert(false);
-}
-
 }  // namespace
 
 int main() {
-  glfwSetErrorCallback(glfw_error_cb);
+  glfwSetErrorCallback(dusk::cb::glfw_error);
 
   if (!glfwInit()) {
     std::println(stderr, "Failed to initialize GLFW.");
@@ -124,7 +85,7 @@ int main() {
   };
   wgpu::Adapter adapter{};
   instance.RequestAdapter(&adapter_opts, wgpu::CallbackMode::AllowSpontaneous,
-                          adapter_request_cb, &adapter);
+                          dusk::cb::adapter_request, &adapter);
 
   dusk::log::emit(adapter);
 
@@ -132,8 +93,8 @@ int main() {
   wgpu::DeviceDescriptor deviceDesc{};
   deviceDesc.label = "Primary Device";
   deviceDesc.SetDeviceLostCallback(wgpu::CallbackMode::AllowProcessEvents,
-                                   device_lost_cb);
-  deviceDesc.SetUncapturedErrorCallback(uncaptured_error_cb);
+                                   dusk::cb::device_lost);
+  deviceDesc.SetUncapturedErrorCallback(dusk::cb::uncaptured_error);
   auto device = adapter.CreateDevice(&deviceDesc);
 
   dusk::log::emit(device);

--- a/src/example_04/CMakeLists.txt
+++ b/src/example_04/CMakeLists.txt
@@ -15,6 +15,8 @@
 add_executable(dusk_example_04 ${DUSK_SRCS})
 dusk_compile_options(dusk_example_04)
 target_sources(dusk_example_04 PRIVATE
+  ../common/callback.cc
+  ../common/callback.h
   ../common/glfw.h
   ../common/log.cc
   ../common/log.h

--- a/src/example_04/main.cc
+++ b/src/example_04/main.cc
@@ -17,6 +17,7 @@
 #include <numbers>
 #include <print>
 
+#include "src/common/callback.h"
 #include "src/common/glfw.h"
 #include "src/common/log.h"
 #include "src/common/webgpu_helpers.h"
@@ -110,50 +111,10 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4f {
 }
 )";
 
-void adapter_request_cb(wgpu::RequestAdapterStatus status,
-                        wgpu::Adapter a,
-                        wgpu::StringView message,
-                        wgpu::Adapter* data) {
-  if (status != wgpu::RequestAdapterStatus::Success) {
-    std::println(stderr, "Adapter request failed: {}",
-                 std::string_view(message));
-    exit(1);
-  }
-  *data = a;
-}
-
-void device_lost_cb([[maybe_unused]] const wgpu::Device& device,
-                    wgpu::DeviceLostReason reason,
-                    struct wgpu::StringView message) {
-  std::print(stderr, "device lost: {}", dusk::log::to_str(reason));
-  if (message.length > 0) {
-    std::print(stderr, ": {}", std::string_view(message));
-  }
-  std::println(stderr, "");
-}
-
-void uncaptured_error_cb
-    [[noreturn]] ([[maybe_unused]] const wgpu::Device& device,
-                  wgpu::ErrorType type,
-                  struct wgpu::StringView message) {
-  std::print(stderr, "uncaptured error: {}", dusk::log::to_str(type));
-  if (message.length > 0) {
-    std::print(stderr, ": {}", std::string_view(message));
-  }
-
-  std::println(stderr, "");
-  assert(false);
-};
-
-void glfw_error_cb [[noreturn]] (int code, const char* message) {
-  std::println(stderr, "GLFW error: {}: {}", code, message);
-  assert(false);
-}
-
 }  // namespace
 
 int main() {
-  glfwSetErrorCallback(glfw_error_cb);
+  glfwSetErrorCallback(dusk::cb::glfw_error);
 
   if (!glfwInit()) {
     std::println(stderr, "Failed to initialize GLFW.");
@@ -181,7 +142,7 @@ int main() {
   };
   wgpu::Adapter adapter{};
   instance.RequestAdapter(&adapter_opts, wgpu::CallbackMode::AllowSpontaneous,
-                          adapter_request_cb, &adapter);
+                          dusk::cb::adapter_request, &adapter);
 
   dusk::log::emit(adapter);
 
@@ -189,8 +150,8 @@ int main() {
   wgpu::DeviceDescriptor deviceDesc{};
   deviceDesc.label = "Primary Device";
   deviceDesc.SetDeviceLostCallback(wgpu::CallbackMode::AllowProcessEvents,
-                                   device_lost_cb);
-  deviceDesc.SetUncapturedErrorCallback(uncaptured_error_cb);
+                                   dusk::cb::device_lost);
+  deviceDesc.SetUncapturedErrorCallback(dusk::cb::uncaptured_error);
   auto device = adapter.CreateDevice(&deviceDesc);
 
   dusk::log::emit(device);

--- a/src/example_05/CMakeLists.txt
+++ b/src/example_05/CMakeLists.txt
@@ -15,6 +15,8 @@
 add_executable(dusk_example_05 ${DUSK_SRCS})
 dusk_compile_options(dusk_example_05)
 target_sources(dusk_example_05 PRIVATE
+  ../common/callback.cc
+  ../common/callback.h
   ../common/glfw.h
   ../common/log.cc
   ../common/log.h

--- a/src/example_05/main.cc
+++ b/src/example_05/main.cc
@@ -19,6 +19,7 @@
 #include <print>
 #include <string>
 
+#include "src/common/callback.h"
 #include "src/common/glfw.h"
 #include "src/common/log.h"
 #include "src/common/webgpu_helpers.h"
@@ -119,50 +120,10 @@ fn fs_main(in : VertexOutput) -> @location(0) vec4f {
 }
 )";
 
-void adapter_request_cb(wgpu::RequestAdapterStatus status,
-                        wgpu::Adapter a,
-                        wgpu::StringView message,
-                        wgpu::Adapter* data) {
-  if (status != wgpu::RequestAdapterStatus::Success) {
-    std::println(stderr, "Adapter request failed: {}",
-                 std::string_view(message));
-    exit(1);
-  }
-  *data = a;
-}
-
-void device_lost_cb([[maybe_unused]] const wgpu::Device& device,
-                    wgpu::DeviceLostReason reason,
-                    struct wgpu::StringView message) {
-  std::print(stderr, "device lost: {}", dusk::log::to_str(reason));
-  if (message.length > 0) {
-    std::print(stderr, ": {}", std::string_view(message));
-  }
-  std::println(stderr, "");
-}
-
-void uncaptured_error_cb
-    [[noreturn]] ([[maybe_unused]] const wgpu::Device& device,
-                  wgpu::ErrorType type,
-                  struct wgpu::StringView message) {
-  std::print(stderr, "uncaptured error: {}", dusk::log::to_str(type));
-  if (message.length > 0) {
-    std::print(stderr, ": {}", std::string_view(message));
-  }
-
-  std::println(stderr, "");
-  assert(false);
-};
-
-void glfw_error_cb [[noreturn]] (int code, const char* message) {
-  std::println(stderr, "GLFW error: {}: {}", code, message);
-  assert(false);
-}
-
 }  // namespace
 
 int main() {
-  glfwSetErrorCallback(glfw_error_cb);
+  glfwSetErrorCallback(dusk::cb::glfw_error);
 
   if (!glfwInit()) {
     std::println(stderr, "Failed to initialize GLFW.");
@@ -190,7 +151,7 @@ int main() {
   };
   wgpu::Adapter adapter{};
   instance.RequestAdapter(&adapter_opts, wgpu::CallbackMode::AllowSpontaneous,
-                          adapter_request_cb, &adapter);
+                          dusk::cb::adapter_request, &adapter);
 
   dusk::log::emit(adapter);
 
@@ -198,8 +159,8 @@ int main() {
   wgpu::DeviceDescriptor deviceDesc{};
   deviceDesc.label = "Primary Device";
   deviceDesc.SetDeviceLostCallback(wgpu::CallbackMode::AllowProcessEvents,
-                                   device_lost_cb);
-  deviceDesc.SetUncapturedErrorCallback(uncaptured_error_cb);
+                                   dusk::cb::device_lost);
+  deviceDesc.SetUncapturedErrorCallback(dusk::cb::uncaptured_error);
   auto device = adapter.CreateDevice(&deviceDesc);
 
   dusk::log::emit(device);


### PR DESCRIPTION
The 4 common callback routines are moved to the common folder as they're identical between the examples.