### PR TITLE
Turn common into a cmake library.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+add_subdirectory(common)
+
 add_subdirectory(example_01)
 add_subdirectory(example_02)
 add_subdirectory(example_03)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2022 The Dusk Authors
+# Copyright 2025 The Dusk Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,15 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(dusk_example_02)
-dusk_compile_options(dusk_example_02)
-target_sources(dusk_example_02 PRIVATE
-  main.cc
+add_library(dusk-common)
+add_library(dusk::common ALIAS dusk-common)
+dusk_compile_options(dusk-common)
+target_sources(dusk-common PRIVATE
+  callback.cc
+  callback.h
+  glfw.h
+  log.cc
+  log.h
+  webgpu_helpers.cc
+  webgpu_helpers.h
+  wgpu.h
 )
-target_link_libraries(dusk_example_02
-  dusk::common
-  webgpu_dawn
+
+target_link_libraries(dusk-common PRIVATE
   webgpu_cpp
-  webgpu_glfw
-  glfw
 )

--- a/src/example_01/CMakeLists.txt
+++ b/src/example_01/CMakeLists.txt
@@ -15,14 +15,10 @@
 add_executable(dusk_example_01)
 dusk_compile_options(dusk_example_01)
 target_sources(dusk_example_01 PRIVATE
-  ../common/callback.cc
-  ../common/callback.h
-  ../common/log.cc
-  ../common/log.h
-  ../common/wgpu.h
   main.cc
 )
 target_link_libraries(dusk_example_01
+  dusk::common
   webgpu_dawn
   webgpu_cpp
 )

--- a/src/example_03/CMakeLists.txt
+++ b/src/example_03/CMakeLists.txt
@@ -15,17 +15,10 @@
 add_executable(dusk_example_03 ${DUSK_SRCS})
 dusk_compile_options(dusk_example_03)
 target_sources(dusk_example_03 PRIVATE
-  ../common/callback.cc
-  ../common/callback.h
-  ../common/glfw.h
-  ../common/log.cc
-  ../common/log.h
-  ../common/webgpu_helpers.cc
-  ../common/webgpu_helpers.h
-  ../common/wgpu.h
   main.cc
 )
 target_link_libraries(dusk_example_03
+  dusk::common
   webgpu_dawn
   webgpu_cpp
   webgpu_glfw

--- a/src/example_04/CMakeLists.txt
+++ b/src/example_04/CMakeLists.txt
@@ -15,20 +15,13 @@
 add_executable(dusk_example_04 ${DUSK_SRCS})
 dusk_compile_options(dusk_example_04)
 target_sources(dusk_example_04 PRIVATE
-  ../common/callback.cc
-  ../common/callback.h
-  ../common/glfw.h
-  ../common/log.cc
-  ../common/log.h
-  ../common/webgpu_helpers.cc
-  ../common/webgpu_helpers.h
-  ../common/wgpu.h
   main.cc
   mat4.cc
   mat4.h
   vec3.h
 )
 target_link_libraries(dusk_example_04
+  dusk::common
   webgpu_dawn
   webgpu_cpp
   webgpu_glfw

--- a/src/example_05/CMakeLists.txt
+++ b/src/example_05/CMakeLists.txt
@@ -15,20 +15,13 @@
 add_executable(dusk_example_05 ${DUSK_SRCS})
 dusk_compile_options(dusk_example_05)
 target_sources(dusk_example_05 PRIVATE
-  ../common/callback.cc
-  ../common/callback.h
-  ../common/glfw.h
-  ../common/log.cc
-  ../common/log.h
-  ../common/webgpu_helpers.cc
-  ../common/webgpu_helpers.h
-  ../common/wgpu.h
   main.cc
   mat4.cc
   mat4.h
   vec3.h
 )
 target_link_libraries(dusk_example_05
+  dusk::common
   webgpu_dawn
   webgpu_cpp
   webgpu_glfw


### PR DESCRIPTION
Instead of including each common file in the example cmake files, just turn common into a library and use that as needed.