### PR TITLE
Update common functions and docs.

### DIFF
--- a/src/common/callback.cc
+++ b/src/common/callback.cc
@@ -22,7 +22,7 @@
 namespace dusk::cb {
 
 void adapter_request(wgpu::RequestAdapterStatus status,
-                     wgpu::Adapter a,
+                     wgpu::Adapter adapter,
                      wgpu::StringView message,
                      wgpu::Adapter* data) {
   if (status != wgpu::RequestAdapterStatus::Success) {
@@ -30,7 +30,7 @@ void adapter_request(wgpu::RequestAdapterStatus status,
                  std::string_view(message));
     exit(1);
   }
-  *data = a;
+  *data = adapter;
 }
 
 void device_lost([[maybe_unused]] const wgpu::Device& device,

--- a/src/common/callback.h
+++ b/src/common/callback.h
@@ -14,21 +14,47 @@
 
 #include "src/common/wgpu.h"
 
+/// Callbacks which are common over all of the examples.
 namespace dusk::cb {
 
+/// Callback when making a WebGPU Adapter Request
+///
+/// @param status reports if the adapter request was successful or not
+/// @param adapter the selected adapter
+/// @param message if the request failed, a message about the failure
+/// @param data the user data attached to the request.
+
+/// @note, the type of the `data` member matches the type of data attached when
+/// calling `instance.requestAdapter`. We happen to be passing a `wgpu::Adapter`
+/// so our type is `wgpu::Adapter*` but if you used a custom `struct MyStruct`
+/// for example you'd use `MyStruct*`.
 void adapter_request(wgpu::RequestAdapterStatus status,
-                     wgpu::Adapter a,
+                     wgpu::Adapter adapter,
                      wgpu::StringView message,
                      wgpu::Adapter* data);
 
-void device_lost([[maybe_unused]] const wgpu::Device& device,
+/// Callback when the GPU is lost to WebGPU
+///
+/// @param device the device associated to the lost GPU
+/// @param reason the reason the device was lost
+/// @param message any context information
+void device_lost(const wgpu::Device& device,
                  wgpu::DeviceLostReason reason,
                  struct wgpu::StringView message);
 
-void uncaptured_error [[noreturn]] ([[maybe_unused]] const wgpu::Device& device,
+/// Callback for any error not captured in an error scope.
+///
+/// @param device the device where the error originated
+/// @param type the type of error
+/// @param message any context information on the error
+void uncaptured_error [[noreturn]] (const wgpu::Device& device,
                                     wgpu::ErrorType type,
                                     struct wgpu::StringView message);
 
+/// Callback for a GLFW error
+///
+/// @param code the error code
+/// @param message any context information for the error.
 void glfw_error [[noreturn]] (int code, const char* message);
 
 }  // namespace dusk::cb

--- a/src/common/log.cc
+++ b/src/common/log.cc
@@ -265,7 +265,7 @@ std::string to_str(const wgpu::AdapterInfo& info) {
   return out.str();
 }
 
-std::string limits(const wgpu::Limits& limits, const std::string& indent) {
+std::string limits(const wgpu::Limits& limits, std::string_view indent) {
   std::stringstream out;
   std::println(out, "{}maxTextureDimension1D: {}", indent,
                format_number(limits.maxTextureDimension1D));

--- a/src/common/log.h
+++ b/src/common/log.h
@@ -19,24 +19,85 @@
 
 #include "src/common/wgpu.h"
 
+/// Methods used to log various bits of data from WebGPU.
 namespace dusk::log {
 
+/// Creates a textual version of the the feature name
+///
+/// @param f the feature name to convert
+/// @returns the string name
 std::string_view to_str(wgpu::FeatureName f);
+
+/// Creates a textual version of the the adapter type
+///
+/// @param type the adapter type to convert
+/// @returns the string name
 std::string_view to_str(wgpu::AdapterType type);
+
+/// Creates a textual version of the the backend type
+///
+/// @param type the backend type to convert
+/// @returns the string name
 std::string_view to_str(wgpu::BackendType type);
+
+/// Creates a textual version of the the device lost reason
+///
+/// @param f the device lost reason to convert
+/// @returns the string name
 std::string_view to_str(wgpu::DeviceLostReason reason);
+
+/// Creates a textual version of the the error type
+///
+/// @param f the error type to convert
+/// @returns the string name
 std::string_view to_str(wgpu::ErrorType type);
 
+/// Creates a textual version of the the adapter information
+///
+/// @param info the adapter info to convert
+/// @returns the string representation
 std::string to_str(const wgpu::AdapterInfo& info);
-std::string limits(const wgpu::Limits& limits, const std::string& indent);
 
+/// Creates a textual version of the limits
+///
+/// @param limits the limits to convert
+/// @param indent the amount to indent each limit string
+/// @returns the string representation
+std::string limits(const wgpu::Limits& limits, std::string_view indent);
+
+/// Emits the adapter info to `stderr`
+///
+/// @param adapter the adapter to emit from
 void emit_adapter_info(wgpu::Adapter& adapter);
+
+/// Emits the adapter features to `stderr`
+///
+/// @param adapter the adapter to emit from
 void emit_adapter_features(wgpu::Adapter& adapter);
+
+/// Emits the adapter limits to `stderr`
+///
+/// @param adapter the adapter to emit from
 void emit_adapter_limits(wgpu::Adapter& adapter);
+
+/// Emits the adapter to `stderr`
+///
+/// @param adapter the adapter to emit
 void emit(wgpu::Adapter& adapter);
 
+/// Emits the device features to `stderr`
+///
+/// @param device the device to emit from
 void emit_device_features(wgpu::Device& device);
+
+/// Emits the device limits to `stderr`
+///
+/// @param device the device to emit from
 void emit_device_limits(wgpu::Device& device);
+
+/// Emits the device to `stderr`
+///
+/// @param device the device to emit
 void emit(wgpu::Device& device);
 
 }  // namespace dusk::log

--- a/src/common/webgpu_helpers.cc
+++ b/src/common/webgpu_helpers.cc
@@ -17,34 +17,34 @@
 namespace dusk::webgpu {
 
 wgpu::Buffer create_buffer(const wgpu::Device& device,
-                           const std::string& label,
-                           uint64_t size,
+                           std::string_view label,
+                           uint64_t size_in_bytes,
                            wgpu::BufferUsage usage) {
   wgpu::BufferDescriptor desc{
-      .label = label.c_str(),
+      .label = label,
       .usage = usage | wgpu::BufferUsage::CopyDst,
-      .size = size,
+      .size = size_in_bytes,
   };
   return device.CreateBuffer(&desc);
 }
 
 wgpu::Buffer create_buffer(const wgpu::Device& device,
-                           const std::string& label,
+                           std::string_view label,
                            const void* data,
-                           uint64_t size,
+                           uint64_t size_in_bytes,
                            wgpu::BufferUsage usage) {
-  auto buffer = create_buffer(device, label, size, usage);
-  device.GetQueue().WriteBuffer(buffer, 0, data, size);
+  auto buffer = create_buffer(device, label, size_in_bytes, usage);
+  device.GetQueue().WriteBuffer(buffer, 0, data, size_in_bytes);
   return buffer;
 }
 
 wgpu::Texture create_texture(const wgpu::Device& device,
-                             const std::string& label,
+                             std::string_view label,
                              wgpu::Extent3D extent,
                              wgpu::TextureFormat format,
                              wgpu::TextureUsage usage) {
   wgpu::TextureDescriptor desc{
-      .label = label.c_str(),
+      .label = label,
       .usage = usage,
       .size = extent,
       .format = format,
@@ -54,14 +54,14 @@ wgpu::Texture create_texture(const wgpu::Device& device,
 }
 
 wgpu::ShaderModule create_shader_module(const wgpu::Device& device,
-                                        const std::string& label,
-                                        const std::string& src) {
+                                        std::string_view label,
+                                        std::string_view src) {
   wgpu::ShaderSourceWGSL wgslDesc;
-  wgslDesc.code = src.c_str();
+  wgslDesc.code = src;
 
   wgpu::ShaderModuleDescriptor desc{
       .nextInChain = &wgslDesc,
-      .label = label.c_str(),
+      .label = label,
   };
   return device.CreateShaderModule(&desc);
 }

--- a/src/common/webgpu_helpers.h
+++ b/src/common/webgpu_helpers.h
@@ -12,31 +12,61 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <string>
+#include <string_view>
 
 #include "src/common/wgpu.h"
 
+/// Helper methods for interacting with the WebGPU API.
 namespace dusk::webgpu {
 
+/// Creates a new GPU buffer
+///
+/// @param device the device to associate the buffer too
+/// @param label the label to attach to the buffer
+/// @param size_in_bytes the byte size of the buffer
+/// @param usage the usage of the buffer
+/// @returns a new WebGPU buffer of the selected size
 wgpu::Buffer create_buffer(const wgpu::Device& device,
-                           const std::string& label,
-                           uint64_t size,
+                           std::string_view label,
+                           uint64_t size_in_bytes,
                            wgpu::BufferUsage usage);
 
+/// Creates a new GPU buffer initialized with the given data
+///
+/// @param device the device to associate the buffer too
+/// @param label the label to attach to the buffer
+/// @param data the initial data to write to the buffer
+/// @param size_in_bytes the byte size of the buffer
+/// @param usage the usage of the buffer
+/// @returns a new WebGPU buffer of the selected size
 wgpu::Buffer create_buffer(const wgpu::Device& device,
-                           const std::string& label,
+                           std::string_view label,
                            const void* data,
-                           uint64_t size,
+                           uint64_t size_in_bytes,
                            wgpu::BufferUsage usage);
 
+/// Creates a new GPU texture
+///
+/// @param device the device to associate the buffer too
+/// @param label the label to attach to the texture
+/// @param extent the extent of the texture
+/// @param format the texture format
+/// @param usage the texture usage
+/// @returns a new WebGPU texture
 wgpu::Texture create_texture(const wgpu::Device& device,
-                             const std::string& label,
+                             std::string_view label,
                              wgpu::Extent3D extent,
                              wgpu::TextureFormat format,
                              wgpu::TextureUsage usage);
 
+/// Creates a shader module from the given shader
+///
+/// @param device the device to create the module on
+/// @param label the label to attach to the shader
+/// @param src the shader source
+/// @returns a new WebGPU ShaderModule
 wgpu::ShaderModule create_shader_module(const wgpu::Device& device,
-                                        const std::string& label,
-                                        const std::string& src);
+                                        std::string_view label,
+                                        std::string_view src);
 
 }  // namespace dusk::webgpu


### PR DESCRIPTION
Add documentation to the common functions. Update several of the `const std::string&` parameters to use `std::string_view` instead.