### PR TITLE
Catch errors from log routines.

### DIFF
--- a/src/common/log.cc
+++ b/src/common/log.cc
@@ -17,6 +17,7 @@
 #include <cassert>
 #include <print>
 #include <sstream>
+#include "src/common/expected.h"
 
 namespace dusk::log {
 namespace {
@@ -437,10 +438,11 @@ std::expected<void, std::string> emit_instance_language_features(
   return {};
 }
 
-void emit_adapter_info(wgpu::Adapter& adapter) {
+std::expected<void, std::string> emit_adapter_info(wgpu::Adapter& adapter) {
   wgpu::AdapterInfo info;
-  adapter.GetInfo(&info);
+  WGPU_TRY(adapter.GetInfo(&info));
   std::println(stderr, "{}", to_str(info));
+  return {};
 }
 
 void emit_adapter_features(wgpu::Adapter& adapter) {
@@ -453,13 +455,13 @@ void emit_adapter_features(wgpu::Adapter& adapter) {
   }
 }
 
-void emit_adapter_limits(wgpu::Adapter& adapter) {
+std::expected<void, std::string> emit_adapter_limits(wgpu::Adapter& adapter) {
   wgpu::SupportedLimits adapter_limits;
-  if (adapter.GetLimits(&adapter_limits)) {
-    std::println(stderr, "");
-    std::println(stderr, "Adapter Limits:");
-    std::println(stderr, "{}", limits(adapter_limits.limits, "  "));
-  }
+  WGPU_TRY(adapter.GetLimits(&adapter_limits));
+
+  std::println(stderr, "");
+  std::println(stderr, "Adapter Limits:");
+  std::println(stderr, "{}", limits(adapter_limits.limits, "  "));
 
   {
     wgpu::ChainedStructOut* next = adapter_limits.nextInChain;
@@ -485,12 +487,14 @@ void emit_adapter_limits(wgpu::Adapter& adapter) {
       next = next->nextInChain;
     }
   }
+  return {};
 }
 
-void emit(wgpu::Adapter& adapter) {
-  emit_adapter_info(adapter);
+std::expected<void, std::string> emit(wgpu::Adapter& adapter) {
+  VALID_OR_PROPAGATE(emit_adapter_info(adapter));
   emit_adapter_features(adapter);
-  emit_adapter_limits(adapter);
+  VALID_OR_PROPAGATE(emit_adapter_limits(adapter));
+  return {};
 }
 
 void emit_device_features(wgpu::Device& device) {
@@ -503,18 +507,19 @@ void emit_device_features(wgpu::Device& device) {
   }
 }
 
-void emit_device_limits(wgpu::Device& device) {
+std::expected<void, std::string> emit_device_limits(wgpu::Device& device) {
   wgpu::SupportedLimits deviceLimits;
-  if (device.GetLimits(&deviceLimits)) {
-    std::println(stderr, "");
-    std::println(stderr, "Device Limits:");
-    std::println(stderr, "{}", limits(deviceLimits.limits, "  "));
-  }
+  WGPU_TRY(device.GetLimits(&deviceLimits));
+  std::println(stderr, "");
+  std::println(stderr, "Device Limits:");
+  std::println(stderr, "{}", limits(deviceLimits.limits, "  "));
+  return {};
 }
 
-void emit(wgpu::Device& device) {
+std::expected<void, std::string> emit(wgpu::Device& device) {
   emit_device_features(device);
-  emit_device_limits(device);
+  VALID_OR_PROPAGATE(emit_device_limits(device));
+  return {};
 }
 
 }  // namespace dusk::log

--- a/src/common/log.h
+++ b/src/common/log.h
@@ -97,7 +97,7 @@ std::expected<void, std::string> emit_instance_language_features(
 /// Emits the adapter info to `stderr`
 ///
 /// @param adapter the adapter to emit from
-void emit_adapter_info(wgpu::Adapter& adapter);
+std::expected<void, std::string> emit_adapter_info(wgpu::Adapter& adapter);
 
 /// Emits the adapter features to `stderr`
 ///
@@ -107,12 +107,12 @@ void emit_adapter_features(wgpu::Adapter& adapter);
 /// Emits the adapter limits to `stderr`
 ///
 /// @param adapter the adapter to emit from
-void emit_adapter_limits(wgpu::Adapter& adapter);
+std::expected<void, std::string> emit_adapter_limits(wgpu::Adapter& adapter);
 
 /// Emits the adapter to `stderr`
 ///
 /// @param adapter the adapter to emit
-void emit(wgpu::Adapter& adapter);
+std::expected<void, std::string> emit(wgpu::Adapter& adapter);
 
 /// Emits the device features to `stderr`
 ///
@@ -122,11 +122,11 @@ void emit_device_features(wgpu::Device& device);
 /// Emits the device limits to `stderr`
 ///
 /// @param device the device to emit from
-void emit_device_limits(wgpu::Device& device);
+std::expected<void, std::string> emit_device_limits(wgpu::Device& device);
 
 /// Emits the device to `stderr`
 ///
 /// @param device the device to emit
-void emit(wgpu::Device& device);
+std::expected<void, std::string> emit(wgpu::Device& device);
 
 }  // namespace dusk::log

--- a/src/example_01/main.cc
+++ b/src/example_01/main.cc
@@ -15,6 +15,7 @@
 #include <print>
 
 #include "src/common/callback.h"
+#include "src/common/expected.h"
 #include "src/common/log.h"
 #include "src/common/wgpu.h"
 
@@ -24,7 +25,7 @@ int main() {
   dusk::log::emit(caps);
 
   auto instance = wgpu::CreateInstance();
-  dusk::log::emit_instance_language_features(instance);
+  dusk::valid_or_exit(dusk::log::emit_instance_language_features(instance));
 
   // Get Adapter
   wgpu::RequestAdapterOptions adapter_opts{
@@ -34,7 +35,7 @@ int main() {
   instance.RequestAdapter(&adapter_opts, wgpu::CallbackMode::AllowSpontaneous,
                           dusk::cb::adapter_request, &adapter);
 
-  dusk::log::emit(adapter);
+  dusk::valid_or_exit(dusk::log::emit(adapter));
 
   // Get device
   wgpu::DeviceDescriptor device_desc{};
@@ -44,7 +45,7 @@ int main() {
   device_desc.SetUncapturedErrorCallback(dusk::cb::uncaptured_error);
 
   wgpu::Device device = adapter.CreateDevice(&device_desc);
-  dusk::log::emit(device);
+  dusk::valid_or_exit(dusk::log::emit(device));
 
   return 0;
 }

--- a/src/example_02/main.cc
+++ b/src/example_02/main.cc
@@ -16,6 +16,7 @@
 #include <print>
 
 #include "src/common/callback.h"
+#include "src/common/expected.h"
 #include "src/common/glfw.h"
 #include "src/common/log.h"
 #include "src/common/webgpu_helpers.h"
@@ -86,7 +87,7 @@ int main() {
   instance.RequestAdapter(&adapter_opts, wgpu::CallbackMode::AllowSpontaneous,
                           dusk::cb::adapter_request, &adapter);
 
-  dusk::log::emit(adapter);
+  dusk::valid_or_exit(dusk::log::emit(adapter));
 
   // Get device
   wgpu::DeviceDescriptor deviceDesc{};
@@ -96,7 +97,7 @@ int main() {
   deviceDesc.SetUncapturedErrorCallback(dusk::cb::uncaptured_error);
   auto device = adapter.CreateDevice(&deviceDesc);
 
-  dusk::log::emit(device);
+  dusk::valid_or_exit(dusk::log::emit(device));
 
   // Set up surface for drawing and presenting
   wgpu::SurfaceCapabilities capabilities;

--- a/src/example_03/main.cc
+++ b/src/example_03/main.cc
@@ -16,6 +16,7 @@
 #include <print>
 
 #include "src/common/callback.h"
+#include "src/common/expected.h"
 #include "src/common/glfw.h"
 #include "src/common/log.h"
 #include "src/common/webgpu_helpers.h"
@@ -87,7 +88,7 @@ int main() {
   instance.RequestAdapter(&adapter_opts, wgpu::CallbackMode::AllowSpontaneous,
                           dusk::cb::adapter_request, &adapter);
 
-  dusk::log::emit(adapter);
+  dusk::valid_or_exit(dusk::log::emit(adapter));
 
   // Get device
   wgpu::DeviceDescriptor deviceDesc{};
@@ -97,7 +98,7 @@ int main() {
   deviceDesc.SetUncapturedErrorCallback(dusk::cb::uncaptured_error);
   auto device = adapter.CreateDevice(&deviceDesc);
 
-  dusk::log::emit(device);
+  dusk::valid_or_exit(dusk::log::emit(device));
 
   // Set up surface for drawing and presenting
   wgpu::SurfaceCapabilities capabilities;

--- a/src/example_04/main.cc
+++ b/src/example_04/main.cc
@@ -18,6 +18,7 @@
 #include <print>
 
 #include "src/common/callback.h"
+#include "src/common/expected.h"
 #include "src/common/glfw.h"
 #include "src/common/log.h"
 #include "src/common/mat4.h"
@@ -144,7 +145,7 @@ int main() {
   instance.RequestAdapter(&adapter_opts, wgpu::CallbackMode::AllowSpontaneous,
                           dusk::cb::adapter_request, &adapter);
 
-  dusk::log::emit(adapter);
+  dusk::valid_or_exit(dusk::log::emit(adapter));
 
   // Get device
   wgpu::DeviceDescriptor deviceDesc{};
@@ -154,7 +155,7 @@ int main() {
   deviceDesc.SetUncapturedErrorCallback(dusk::cb::uncaptured_error);
   auto device = adapter.CreateDevice(&deviceDesc);
 
-  dusk::log::emit(device);
+  dusk::valid_or_exit(dusk::log::emit(device));
 
   // Setup surface for drawing and presenting
   wgpu::SurfaceCapabilities capabilities;

--- a/src/example_05/main.cc
+++ b/src/example_05/main.cc
@@ -20,6 +20,7 @@
 #include <string>
 
 #include "src/common/callback.h"
+#include "src/common/expected.h"
 #include "src/common/glfw.h"
 #include "src/common/log.h"
 #include "src/common/mat4.h"
@@ -153,7 +154,7 @@ int main() {
   instance.RequestAdapter(&adapter_opts, wgpu::CallbackMode::AllowSpontaneous,
                           dusk::cb::adapter_request, &adapter);
 
-  dusk::log::emit(adapter);
+  dusk::valid_or_exit(dusk::log::emit(adapter));
 
   // Get device
   wgpu::DeviceDescriptor deviceDesc{};
@@ -163,7 +164,7 @@ int main() {
   deviceDesc.SetUncapturedErrorCallback(dusk::cb::uncaptured_error);
   auto device = adapter.CreateDevice(&deviceDesc);
 
-  dusk::log::emit(device);
+  dusk::valid_or_exit(dusk::log::emit(device));
 
   // Setup surface for drawing and presenting
   wgpu::SurfaceCapabilities capabilities;


### PR DESCRIPTION
Add wrappers to catch the errors from the various logging routines and propagate them back through `main`.