### PR TITLE
Use the webgpu_cpp_print helpers from Dawn.

### DIFF
--- a/src/common/log.cc
+++ b/src/common/log.cc
@@ -17,6 +17,12 @@
 #include <cassert>
 #include <print>
 #include <sstream>
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include <webgpu/webgpu_cpp_print.h>
+#pragma clang diagnostic pop
+
 #include "src/common/expected.h"
 
 namespace dusk::log {
@@ -39,279 +45,52 @@ std::string format_number(uint64_t num) {
 
 }  // namespace
 
-std::string_view to_str(wgpu::FeatureName f) {
-  switch (f) {
-    case wgpu::FeatureName::DepthClipControl:
-      return "DepthClipControl";
-    case wgpu::FeatureName::Depth32FloatStencil8:
-      return "Depth32FloatStencil8";
-    case wgpu::FeatureName::TimestampQuery:
-      return "TimestampQuery";
-    case wgpu::FeatureName::TextureCompressionBC:
-      return "TextureCompressionBC";
-    case wgpu::FeatureName::TextureCompressionETC2:
-      return "TextureCompressionETC2";
-    case wgpu::FeatureName::TextureCompressionASTC:
-      return "TextureCompressionASTC";
-    case wgpu::FeatureName::IndirectFirstInstance:
-      return "IndirectFirstInstance";
-    case wgpu::FeatureName::ShaderF16:
-      return "ShaderF16";
-    case wgpu::FeatureName::RG11B10UfloatRenderable:
-      return "RG11B10UfloatRenderable";
-    case wgpu::FeatureName::BGRA8UnormStorage:
-      return "BGRA8UnormStorage";
-    case wgpu::FeatureName::Float32Filterable:
-      return "Float32Filterable";
-    case wgpu::FeatureName::Float32Blendable:
-      return "Float32Blendable";
-    case wgpu::FeatureName::Subgroups:
-      return "Subgroups";
-    case wgpu::FeatureName::DawnInternalUsages:
-      return "DawnInternalUsages";
-    case wgpu::FeatureName::DawnMultiPlanarFormats:
-      return "DawnMultiPlanarFormats";
-    case wgpu::FeatureName::DawnNative:
-      return "DawnNative";
-    case wgpu::FeatureName::ChromiumExperimentalTimestampQueryInsidePasses:
-      return "ChromiumExperimentalTimestampQueryInsidePasses";
-    case wgpu::FeatureName::ImplicitDeviceSynchronization:
-      return "ImplicitDeviceSynchronization";
-    case wgpu::FeatureName::ChromiumExperimentalImmediate:
-      return "ChromiumExperimentalImmediate";
-    case wgpu::FeatureName::TransientAttachments:
-      return "TransientAttachments";
-    case wgpu::FeatureName::MSAARenderToSingleSampled:
-      return "MSAARenderToSingleSampled";
-    case wgpu::FeatureName::DualSourceBlending:
-      return "DualSourceBlending";
-    case wgpu::FeatureName::D3D11MultithreadProtected:
-      return "D3D11MultithreadProtected";
-    case wgpu::FeatureName::ANGLETextureSharing:
-      return "ANGLETextureSharing";
-    case wgpu::FeatureName::PixelLocalStorageCoherent:
-      return "PixelLocalStorageCoherent";
-    case wgpu::FeatureName::PixelLocalStorageNonCoherent:
-      return "PixelLocalStorageNonCoherent";
-    case wgpu::FeatureName::Unorm16TextureFormats:
-      return "Unorm16TextureFormats";
-    case wgpu::FeatureName::Snorm16TextureFormats:
-      return "Snorm16TextureFormats";
-    case wgpu::FeatureName::MultiPlanarFormatExtendedUsages:
-      return "MultiPlanarFormatExtendedUsages";
-    case wgpu::FeatureName::MultiPlanarFormatP010:
-      return "MultiPlanarFormatP010";
-    case wgpu::FeatureName::HostMappedPointer:
-      return "HostMappedPointer";
-    case wgpu::FeatureName::MultiPlanarRenderTargets:
-      return "MultiPlanarRenderTargets";
-    case wgpu::FeatureName::MultiPlanarFormatNv12a:
-      return "MultiPlanarFormatNv12a";
-    case wgpu::FeatureName::FramebufferFetch:
-      return "FramebufferFetch";
-    case wgpu::FeatureName::BufferMapExtendedUsages:
-      return "BufferMapExtendedUsages";
-    case wgpu::FeatureName::AdapterPropertiesMemoryHeaps:
-      return "AdapterPropertiesMemoryHeaps";
-    case wgpu::FeatureName::AdapterPropertiesD3D:
-      return "AdapterPropertiesD3D";
-    case wgpu::FeatureName::AdapterPropertiesVk:
-      return "AdapterPropertiesVk";
-    case wgpu::FeatureName::R8UnormStorage:
-      return "R8UnormStorage";
-    case wgpu::FeatureName::DawnFormatCapabilities:
-      return "DawnFormatCapabilities";
-    case wgpu::FeatureName::DawnDrmFormatCapabilities:
-      return "DawnDrmFormatCapabilities";
-    case wgpu::FeatureName::Norm16TextureFormats:
-      return "Norm16TextureFormats";
-    case wgpu::FeatureName::MultiPlanarFormatNv16:
-      return "MultiPlanarFormatNv16";
-    case wgpu::FeatureName::MultiPlanarFormatNv24:
-      return "MultiPlanarFormatNv24";
-    case wgpu::FeatureName::MultiPlanarFormatP210:
-      return "MultiPlanarFormatP210";
-    case wgpu::FeatureName::MultiPlanarFormatP410:
-      return "MultiPlanarFormatP410";
-    case wgpu::FeatureName::SharedTextureMemoryVkDedicatedAllocation:
-      return "SharedTextureMemoryVkDedicatedAllocation";
-    case wgpu::FeatureName::SharedTextureMemoryAHardwareBuffer:
-      return "SharedTextureMemoryAHardwareBuffer";
-    case wgpu::FeatureName::SharedTextureMemoryDmaBuf:
-      return "SharedTextureMemoryDmaBuf";
-    case wgpu::FeatureName::SharedTextureMemoryOpaqueFD:
-      return "SharedTextureMemoryOpaqueFD";
-    case wgpu::FeatureName::SharedTextureMemoryZirconHandle:
-      return "SharedTextureMemoryZirconHandle";
-    case wgpu::FeatureName::SharedTextureMemoryDXGISharedHandle:
-      return "SharedTextureMemoryDXGISharedHandle";
-    case wgpu::FeatureName::SharedTextureMemoryD3D11Texture2D:
-      return "SharedTextureMemoryD3D11Texture2D";
-    case wgpu::FeatureName::SharedTextureMemoryIOSurface:
-      return "SharedTextureMemoryIOSurface";
-    case wgpu::FeatureName::SharedTextureMemoryEGLImage:
-      return "SharedTextureMemoryEGLImage";
-    case wgpu::FeatureName::SharedFenceVkSemaphoreOpaqueFD:
-      return "SharedFenceVkSemaphoreOpaqueFD";
-    case wgpu::FeatureName::SharedFenceSyncFD:
-      return "SharedFenceSyncFD";
-    case wgpu::FeatureName::SharedFenceVkSemaphoreZirconHandle:
-      return "SharedFenceVkSemaphoreZirconHandle";
-    case wgpu::FeatureName::SharedFenceDXGISharedHandle:
-      return "SharedFenceDXGISharedHandle";
-    case wgpu::FeatureName::SharedFenceMTLSharedEvent:
-      return "SharedFenceMTLSharedEvent";
-    case wgpu::FeatureName::SharedBufferMemoryD3D12Resource:
-      return "SharedBufferMemoryD3D12Resource";
-    case wgpu::FeatureName::StaticSamplers:
-      return "StaticSamplers";
-    case wgpu::FeatureName::YCbCrVulkanSamplers:
-      return "YCbCrVulkanSamplers";
-    case wgpu::FeatureName::ShaderModuleCompilationOptions:
-      return "ShaderModuleCompilationOptions";
-    case wgpu::FeatureName::DawnLoadResolveTexture:
-      return "DawnLoadResolveTexture";
-    case wgpu::FeatureName::DawnPartialLoadResolveTexture:
-      return "DawnPartialLoadResolveTexture";
-    case wgpu::FeatureName::MultiDrawIndirect:
-      return "MultiDrawIndirect";
-    case wgpu::FeatureName::ClipDistances:
-      return "ClipDistances";
-    case wgpu::FeatureName::DawnTexelCopyBufferRowAlignment:
-      return "DawnTexelCopyBufferRowAlignment";
-    case wgpu::FeatureName::FlexibleTextureViews:
-      return "FlexibleTextureViews";
-    case wgpu::FeatureName::TextureCompressionBCSliced3D:
-      return "TextureCompressionBCSliced3D";
-    case wgpu::FeatureName::TextureCompressionASTCSliced3D:
-      return "TextureCompressionASTCSliced3D";
-    case wgpu::FeatureName::CoreFeaturesAndLimits:
-      return "CoreFeaturesAndLimits";
-    case wgpu::FeatureName::ChromiumExperimentalSubgroupMatrix:
-      return "ChromiumExperimentalSubgroupMatrix";
-    case wgpu::FeatureName::SharedFenceEGLSync:
-      return "SharedFenceEGLSync";
-    case wgpu::FeatureName::DawnDeviceAllocatorControl:
-      return "DawnDeviceAllocatorControl";
-  }
-  return "Unknown";
+std::string to_str(wgpu::FeatureName f) {
+  std::stringstream s;
+  s << f;
+  return s.str();
 }
 
-std::string_view to_str(wgpu::WGSLLanguageFeatureName name) {
-  switch (name) {
-    case wgpu::WGSLLanguageFeatureName::ReadonlyAndReadwriteStorageTextures:
-      return "ReadonlyAndReadwriteStorageTextures";
-    case wgpu::WGSLLanguageFeatureName::Packed4x8IntegerDotProduct:
-      return "Packed4x8IntegerDotProduct";
-    case wgpu::WGSLLanguageFeatureName::UnrestrictedPointerParameters:
-      return "UnrestrictedPointerParameters";
-    case wgpu::WGSLLanguageFeatureName::PointerCompositeAccess:
-      return "PointerCompositeAccess";
-    case wgpu::WGSLLanguageFeatureName::ChromiumTestingUnimplemented:
-      return "ChromiumTestingUnimplemented";
-    case wgpu::WGSLLanguageFeatureName::ChromiumTestingUnsafeExperimental:
-      return "ChromiumTestingUnsafeExperimental";
-    case wgpu::WGSLLanguageFeatureName::ChromiumTestingExperimental:
-      return "ChromiumTestingExperimental";
-    case wgpu::WGSLLanguageFeatureName::ChromiumTestingShippedWithKillswitch:
-      return "ChromiumTestingShippedWithKillswitch";
-    case wgpu::WGSLLanguageFeatureName::ChromiumTestingShipped:
-      return "ChromiumTestingShipped";
-    case wgpu::WGSLLanguageFeatureName::SizedBindingArray:
-      return "SizedBindingArray";
-  }
+std::string to_str(wgpu::WGSLLanguageFeatureName name) {
+  std::stringstream s;
+  s << name;
+  return s.str();
 }
 
-std::string_view to_str(wgpu::AdapterType type) {
-  switch (type) {
-    case wgpu::AdapterType::DiscreteGPU:
-      return "discrete GPU";
-    case wgpu::AdapterType::IntegratedGPU:
-      return "integrated GPU";
-    case wgpu::AdapterType::CPU:
-      return "CPU";
-    case wgpu::AdapterType::Unknown:
-      break;
-  }
-  return "unknown";
+std::string to_str(wgpu::AdapterType type) {
+  std::stringstream s;
+  s << type;
+  return s.str();
 }
 
-std::string_view to_str(wgpu::BackendType type) {
-  switch (type) {
-    case wgpu::BackendType::Null:
-      return "Null";
-    case wgpu::BackendType::WebGPU:
-      return "WebGPU";
-    case wgpu::BackendType::D3D11:
-      return "D3D11";
-    case wgpu::BackendType::D3D12:
-      return "D3D12";
-    case wgpu::BackendType::Metal:
-      return "Metal";
-    case wgpu::BackendType::Vulkan:
-      return "Vulkan";
-    case wgpu::BackendType::OpenGL:
-      return "OpenGL";
-    case wgpu::BackendType::OpenGLES:
-      return "OpenGLES";
-    case wgpu::BackendType::Undefined:
-      return "Undefined";
-  }
-  return "unknown";
+std::string to_str(wgpu::BackendType type) {
+  std::stringstream s;
+  s << type;
+  return s.str();
 }
 
-std::string_view to_str(wgpu::DeviceLostReason reason) {
-  switch (reason) {
-    case wgpu::DeviceLostReason::Destroyed:
-      return "Destroyed";
-    case wgpu::DeviceLostReason::FailedCreation:
-      return "FailedCreation";
-    default:
-      return "unknown";
-  }
+std::string to_str(wgpu::DeviceLostReason reason) {
+  std::stringstream s;
+  s << reason;
+  return s.str();
 }
 
-std::string_view to_str(wgpu::ErrorType type) {
-  switch (type) {
-    case wgpu::ErrorType::NoError:
-      return "NoError";
-    case wgpu::ErrorType::Validation:
-      return "Validation";
-    case wgpu::ErrorType::OutOfMemory:
-      return "OutOfMemory";
-    case wgpu::ErrorType::Internal:
-      return "Internal";
-    default:
-      return "unknown";
-  }
+std::string to_str(wgpu::ErrorType type) {
+  std::stringstream s;
+  s << type;
+  return s.str();
 }
 
-std::string_view to_str(wgpu::HeapProperty props) {
-  switch (props) {
-    case wgpu::HeapProperty::DeviceLocal:
-      return "device_local";
-    case wgpu::HeapProperty::HostVisible:
-      return "host_visible";
-    case wgpu::HeapProperty::HostCoherent:
-      return "host_coherent";
-    case wgpu::HeapProperty::HostUncached:
-      return "host_uncached";
-    case wgpu::HeapProperty::HostCached:
-      return "host_cached";
-    case wgpu::HeapProperty::None:
-      return "none";
-  }
+std::string to_str(wgpu::HeapProperty props) {
+  std::stringstream s;
+  s << props;
+  return s.str();
 }
 
-std::string_view to_str(wgpu::PowerPreference pref) {
-  switch (pref) {
-    case wgpu::PowerPreference::LowPower:
-      return "low";
-    case wgpu::PowerPreference::HighPerformance:
-      return "high";
-    default:
-      return "unknown";
-  }
+std::string to_str(wgpu::PowerPreference pref) {
+  std::stringstream s;
+  s << pref;
+  return s.str();
 }
 
 std::string to_str(const wgpu::AdapterInfo& info) {

--- a/src/common/log.h
+++ b/src/common/log.h
@@ -26,49 +26,49 @@ namespace dusk::log {
 ///
 /// @param f the feature name to convert
 /// @returns the string name
-std::string_view to_str(wgpu::FeatureName f);
+std::string to_str(wgpu::FeatureName f);
 
 /// Creates a textual version of the WGSL language feature name
 ///
 /// @Parma f the language feature name to convert
 /// @returns the string name
-std::string_view to_str(wgpu::WGSLLanguageFeatureName f);
+std::string to_str(wgpu::WGSLLanguageFeatureName f);
 
 /// Creates a textual version of the adapter type
 ///
 /// @param type the adapter type to convert
 /// @returns the string name
-std::string_view to_str(wgpu::AdapterType type);
+std::string to_str(wgpu::AdapterType type);
 
 /// Creates a textual version of the backend type
 ///
 /// @param type the backend type to convert
 /// @returns the string name
-std::string_view to_str(wgpu::BackendType type);
+std::string to_str(wgpu::BackendType type);
 
 /// Creates a textual version of the device lost reason
 ///
 /// @param f the device lost reason to convert
 /// @returns the string name
-std::string_view to_str(wgpu::DeviceLostReason reason);
+std::string to_str(wgpu::DeviceLostReason reason);
 
 /// Creates a textual version of the error type
 ///
 /// @param f the error type to convert
 /// @returns the string name
-std::string_view to_str(wgpu::ErrorType type);
+std::string to_str(wgpu::ErrorType type);
 
 /// Creates a textual version of the heap properties
 ///
 /// @param prop the property to emit
 /// @returns the string name
-std::string_view to_str(wgpu::HeapProperty prop);
+std::string to_str(wgpu::HeapProperty prop);
 
 /// Creates a textual version of the power preference
 ///
 /// @param prop the power preference to emit
 /// @returns the string name
-std::string_view to_str(wgpu::PowerPreference pref);
+std::string to_str(wgpu::PowerPreference pref);
 
 /// Creates a textual version of the adapter information
 ///


### PR DESCRIPTION
When emitting logging information, Dawn provides a `webgpu_cpp_print.h` which handles emitting enum information for WebGPU. This should make it simpler to update in the future as we enums will not need to be updated as needed.