### PR TITLE
Fix logging of adapter extensions.

### DIFF
--- a/src/common/callback.cc
+++ b/src/common/callback.cc
@@ -36,6 +36,11 @@ void adapter_request(wgpu::RequestAdapterStatus status,
 void device_lost([[maybe_unused]] const wgpu::Device& device,
                  wgpu::DeviceLostReason reason,
                  struct wgpu::StringView message) {
+  if (message == std::string_view(
+                     "A valid external Instance reference no longer exists.")) {
+    return;
+  }
+
   std::print(stderr, "device lost: {}", dusk::log::to_str(reason));
   if (message.length > 0) {
     std::print(stderr, ": {}", std::string_view(message));

--- a/src/common/log.h
+++ b/src/common/log.h
@@ -76,6 +76,50 @@ std::string to_str(wgpu::PowerPreference pref);
 /// @returns the string representation
 std::string to_str(const wgpu::AdapterInfo& info);
 
+/// Creates a textual version of the subgroup matrix component type
+///
+/// @param type the type to convert
+/// @returns the string representation
+std::string to_str(wgpu::SubgroupMatrixComponentType type);
+
+/// Creates a textual representation of the D3D adapter properties
+///
+/// @param props the properties
+/// @returns the string representation
+std::string to_str(wgpu::AdapterPropertiesD3D* props);
+
+/// Creates a textual representation of the VK adapter properties
+///
+/// @param props the properties
+/// @returns the string representation
+std::string to_str(wgpu::AdapterPropertiesVk* props);
+
+/// Creates a textual representation of the Subgroups adapter properties
+///
+/// @param props the properties
+/// @returns the string representation
+std::string to_str(wgpu::AdapterPropertiesSubgroups* props);
+
+/// Creates a textual representation of the subgroup matrix configuration
+/// adapter properties
+///
+/// @param props the properties
+/// @returns the string representation
+std::string to_str(wgpu::AdapterPropertiesSubgroupMatrixConfigs* props);
+
+/// Creates a textual representation of the memmory heaps adapter properties
+///
+/// @param props the properties
+/// @returns the string representation
+std::string to_str(wgpu::AdapterPropertiesMemoryHeaps* props);
+
+/// Creates a textual representation of the dawn power preference adapter
+/// properties
+///
+/// @param props the props
+/// @returns the string representation
+std::string to_str(wgpu::DawnAdapterPropertiesPowerPreference* props);
+
 /// Creates a textual version of the limits
 ///
 /// @param limits the limits to convert


### PR DESCRIPTION
This CL fixes up the adapter info request to correctly chain the extra data structures if available and then log out the results.

Previously we did not attach the `nextInChain` correctly for each of the features so received no information back.