### PR TITLE
Remove log for examples other then 1.

### DIFF
--- a/src/example_02/main.cc
+++ b/src/example_02/main.cc
@@ -16,9 +16,7 @@
 #include <print>
 
 #include "src/common/callback.h"
-#include "src/common/expected.h"
 #include "src/common/glfw.h"
-#include "src/common/log.h"
 #include "src/common/webgpu_helpers.h"
 #include "src/common/wgpu.h"
 
@@ -87,8 +85,6 @@ int main() {
   instance.RequestAdapter(&adapter_opts, wgpu::CallbackMode::AllowSpontaneous,
                           dusk::cb::adapter_request, &adapter);
 
-  dusk::valid_or_exit(dusk::log::emit(adapter));
-
   // Get device
   wgpu::DeviceDescriptor deviceDesc{};
   deviceDesc.label = "Primary Device";
@@ -96,8 +92,6 @@ int main() {
                                    dusk::cb::device_lost);
   deviceDesc.SetUncapturedErrorCallback(dusk::cb::uncaptured_error);
   auto device = adapter.CreateDevice(&deviceDesc);
-
-  dusk::valid_or_exit(dusk::log::emit(device));
 
   // Set up surface for drawing and presenting
   wgpu::SurfaceCapabilities capabilities;

--- a/src/example_03/main.cc
+++ b/src/example_03/main.cc
@@ -16,9 +16,7 @@
 #include <print>
 
 #include "src/common/callback.h"
-#include "src/common/expected.h"
 #include "src/common/glfw.h"
-#include "src/common/log.h"
 #include "src/common/webgpu_helpers.h"
 #include "src/common/wgpu.h"
 
@@ -88,8 +86,6 @@ int main() {
   instance.RequestAdapter(&adapter_opts, wgpu::CallbackMode::AllowSpontaneous,
                           dusk::cb::adapter_request, &adapter);
 
-  dusk::valid_or_exit(dusk::log::emit(adapter));
-
   // Get device
   wgpu::DeviceDescriptor deviceDesc{};
   deviceDesc.label = "Primary Device";
@@ -97,8 +93,6 @@ int main() {
                                    dusk::cb::device_lost);
   deviceDesc.SetUncapturedErrorCallback(dusk::cb::uncaptured_error);
   auto device = adapter.CreateDevice(&deviceDesc);
-
-  dusk::valid_or_exit(dusk::log::emit(device));
 
   // Set up surface for drawing and presenting
   wgpu::SurfaceCapabilities capabilities;

--- a/src/example_04/main.cc
+++ b/src/example_04/main.cc
@@ -18,9 +18,7 @@
 #include <print>
 
 #include "src/common/callback.h"
-#include "src/common/expected.h"
 #include "src/common/glfw.h"
-#include "src/common/log.h"
 #include "src/common/mat4.h"
 #include "src/common/webgpu_helpers.h"
 #include "src/common/wgpu.h"
@@ -145,8 +143,6 @@ int main() {
   instance.RequestAdapter(&adapter_opts, wgpu::CallbackMode::AllowSpontaneous,
                           dusk::cb::adapter_request, &adapter);
 
-  dusk::valid_or_exit(dusk::log::emit(adapter));
-
   // Get device
   wgpu::DeviceDescriptor deviceDesc{};
   deviceDesc.label = "Primary Device";
@@ -154,8 +150,6 @@ int main() {
                                    dusk::cb::device_lost);
   deviceDesc.SetUncapturedErrorCallback(dusk::cb::uncaptured_error);
   auto device = adapter.CreateDevice(&deviceDesc);
-
-  dusk::valid_or_exit(dusk::log::emit(device));
 
   // Setup surface for drawing and presenting
   wgpu::SurfaceCapabilities capabilities;

--- a/src/example_05/main.cc
+++ b/src/example_05/main.cc
@@ -20,9 +20,7 @@
 #include <string>
 
 #include "src/common/callback.h"
-#include "src/common/expected.h"
 #include "src/common/glfw.h"
-#include "src/common/log.h"
 #include "src/common/mat4.h"
 #include "src/common/webgpu_helpers.h"
 #include "src/common/wgpu.h"
@@ -154,8 +152,6 @@ int main() {
   instance.RequestAdapter(&adapter_opts, wgpu::CallbackMode::AllowSpontaneous,
                           dusk::cb::adapter_request, &adapter);
 
-  dusk::valid_or_exit(dusk::log::emit(adapter));
-
   // Get device
   wgpu::DeviceDescriptor deviceDesc{};
   deviceDesc.label = "Primary Device";
@@ -163,8 +159,6 @@ int main() {
                                    dusk::cb::device_lost);
   deviceDesc.SetUncapturedErrorCallback(dusk::cb::uncaptured_error);
   auto device = adapter.CreateDevice(&deviceDesc);
-
-  dusk::valid_or_exit(dusk::log::emit(device));
 
   // Setup surface for drawing and presenting
   wgpu::SurfaceCapabilities capabilities;


### PR DESCRIPTION
This CL updates the examples to only print the logging information in the first example. This reduces the console output of subsequent examples.