### PR TITLE
Fixup crash on shutdown.

### DIFF
--- a/src/example_02/main.cc
+++ b/src/example_02/main.cc
@@ -77,13 +77,16 @@ int main() {
   auto surface = wgpu::glfw::CreateSurfaceForWindow(instance, window);
 
   // Get Adapter
-  wgpu::RequestAdapterOptions adapter_opts{
-      .powerPreference = wgpu::PowerPreference::HighPerformance,
-      .compatibleSurface = surface,
-  };
+
   wgpu::Adapter adapter{};
-  instance.RequestAdapter(&adapter_opts, wgpu::CallbackMode::AllowSpontaneous,
-                          dusk::cb::adapter_request, &adapter);
+  {
+    wgpu::RequestAdapterOptions adapter_opts{
+        .powerPreference = wgpu::PowerPreference::HighPerformance,
+        .compatibleSurface = surface,
+    };
+    instance.RequestAdapter(&adapter_opts, wgpu::CallbackMode::AllowSpontaneous,
+                            dusk::cb::adapter_request, &adapter);
+  }
 
   // Get device
   wgpu::DeviceDescriptor deviceDesc{};
@@ -200,6 +203,11 @@ int main() {
     device.GetQueue().Submit(1, &commands);
     surface.Present();
   }
+
+  vertexBuffer.Destroy();
+  surface.Unconfigure();
+  surface = nullptr;
+  device.Destroy();
 
   glfwDestroyWindow(window);
   glfwTerminate();

--- a/src/example_03/main.cc
+++ b/src/example_03/main.cc
@@ -78,13 +78,16 @@ int main() {
   auto surface = wgpu::glfw::CreateSurfaceForWindow(instance, window);
 
   // Get Adapter
-  wgpu::RequestAdapterOptions adapter_opts{
-      .powerPreference = wgpu::PowerPreference::HighPerformance,
-      .compatibleSurface = surface,
-  };
   wgpu::Adapter adapter{};
-  instance.RequestAdapter(&adapter_opts, wgpu::CallbackMode::AllowSpontaneous,
-                          dusk::cb::adapter_request, &adapter);
+  {
+    wgpu::RequestAdapterOptions adapter_opts{
+        .powerPreference = wgpu::PowerPreference::HighPerformance,
+        .compatibleSurface = surface,
+    };
+
+    instance.RequestAdapter(&adapter_opts, wgpu::CallbackMode::AllowSpontaneous,
+                            dusk::cb::adapter_request, &adapter);
+  }
 
   // Get device
   wgpu::DeviceDescriptor deviceDesc{};
@@ -206,6 +209,11 @@ int main() {
     device.GetQueue().Submit(1, &commands);
     surface.Present();
   }
+
+  vertexBuffer.Destroy();
+  surface.Unconfigure();
+  surface = nullptr;
+  device.Destroy();
 
   glfwDestroyWindow(window);
   glfwTerminate();

--- a/src/example_04/main.cc
+++ b/src/example_04/main.cc
@@ -135,13 +135,15 @@ int main() {
   auto surface = wgpu::glfw::CreateSurfaceForWindow(instance, window);
 
   // Get Adapter
-  wgpu::RequestAdapterOptions adapter_opts{
-      .powerPreference = wgpu::PowerPreference::HighPerformance,
-      .compatibleSurface = surface,
-  };
   wgpu::Adapter adapter{};
-  instance.RequestAdapter(&adapter_opts, wgpu::CallbackMode::AllowSpontaneous,
-                          dusk::cb::adapter_request, &adapter);
+  {
+    wgpu::RequestAdapterOptions adapter_opts{
+        .powerPreference = wgpu::PowerPreference::HighPerformance,
+        .compatibleSurface = surface,
+    };
+    instance.RequestAdapter(&adapter_opts, wgpu::CallbackMode::AllowSpontaneous,
+                            dusk::cb::adapter_request, &adapter);
+  }
 
   // Get device
   wgpu::DeviceDescriptor deviceDesc{};
@@ -333,6 +335,11 @@ int main() {
     device.GetQueue().Submit(1, &commands);
     surface.Present();
   }
+
+  vertexBuffer.Destroy();
+  surface.Unconfigure();
+  surface = nullptr;
+  device.Destroy();
 
   glfwDestroyWindow(window);
   glfwTerminate();

--- a/src/example_05/main.cc
+++ b/src/example_05/main.cc
@@ -144,13 +144,15 @@ int main() {
   auto surface = wgpu::glfw::CreateSurfaceForWindow(instance, window);
 
   // Get Adapter
-  wgpu::RequestAdapterOptions adapter_opts{
-      .powerPreference = wgpu::PowerPreference::HighPerformance,
-      .compatibleSurface = surface,
-  };
   wgpu::Adapter adapter{};
-  instance.RequestAdapter(&adapter_opts, wgpu::CallbackMode::AllowSpontaneous,
-                          dusk::cb::adapter_request, &adapter);
+  {
+    wgpu::RequestAdapterOptions adapter_opts{
+        .powerPreference = wgpu::PowerPreference::HighPerformance,
+        .compatibleSurface = surface,
+    };
+    instance.RequestAdapter(&adapter_opts, wgpu::CallbackMode::AllowSpontaneous,
+                            dusk::cb::adapter_request, &adapter);
+  }
 
   // Get device
   wgpu::DeviceDescriptor deviceDesc{};
@@ -382,6 +384,11 @@ int main() {
     device.GetQueue().Submit(1, &commands);
     surface.Present();
   }
+
+  vertexBuffer.Destroy();
+  surface.Unconfigure();
+  surface = nullptr;
+  device.Destroy();
 
   glfwDestroyWindow(window);
   glfwTerminate();


### PR DESCRIPTION
When terminating, there were references held which caused various crashes. Make sure we clean up the `AdapterRequestOptions` immediately to remove the reference on the `Ssurface`. Cleanup the `vertexBuffer`, `surface` and `device` before terminating GLFW.