### PR TITLE
Roll dawn

### DIFF
--- a/src/common/log.h
+++ b/src/common/log.h
@@ -94,12 +94,6 @@ std::string to_str(wgpu::AdapterPropertiesD3D* props);
 /// @returns the string representation
 std::string to_str(wgpu::AdapterPropertiesVk* props);
 
-/// Creates a textual representation of the Subgroups adapter properties
-///
-/// @param props the properties
-/// @returns the string representation
-std::string to_str(wgpu::AdapterPropertiesSubgroups* props);
-
 /// Creates a textual representation of the subgroup matrix configuration
 /// adapter properties
 ///
@@ -126,11 +120,6 @@ std::string to_str(wgpu::DawnAdapterPropertiesPowerPreference* props);
 /// @param indent the amount to indent each limit string
 /// @returns the string representation
 std::string limits(const wgpu::Limits& limits, std::string_view indent);
-
-/// Emits the instance capability information
-///
-/// @param caps the instance capabilities
-void emit(wgpu::InstanceCapabilities& caps);
 
 /// Emits the language features known to the instance
 ///

--- a/src/example_01/main.cc
+++ b/src/example_01/main.cc
@@ -20,10 +20,12 @@
 #include "src/common/wgpu.h"
 
 int main() {
-  wgpu::InstanceCapabilities caps{};
-  WGPU_TRY_EXIT(wgpu::GetInstanceCapabilities(&caps));
-  dusk::log::emit(caps);
-
+  // Get the default instance.
+  //
+  // Alternatively, you can use an InstanceDescriptor to request an instance
+  // with specific features (see InstanceFeatureName), minimum limits
+  // (InstanceLimits), or another feature based on a chained struct (see "Can be
+  // chained in InstanceDescriptor" in webgpu_cpp.h header).
   auto instance = wgpu::CreateInstance();
   dusk::valid_or_exit(dusk::log::emit_instance_language_features(instance));
 


### PR DESCRIPTION
- AdapterPropertiesSubgroups was removed: see members on AdapterInfo instead
- maxImmediateSize is a core limit
- InstanceCapabilities no longer exist.  Instead, request an instance with given limits.